### PR TITLE
Some added type safety to getTranslations

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -56,7 +56,7 @@ trait HasTranslations
     {
         $this->guardAgainstUntranslatableAttribute($key);
 
-        return json_decode($this->getAttributes()[$key] ?? '{}', true);
+        return json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true);
     }
 
     /**


### PR DESCRIPTION
Funky syntax, not sure if it's the way to go.

If the `$key` field exists biut is empty, an empty string will be json decoded making the function return null and crashing. We need to do a check if the key is set and isn't empty.