### PR TITLE
Locale-less model queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $newsItem
    ->setTranslation('name', 'en', 'Name in English');
    ->setTranslation('name', 'nl', 'Naam in het Nederlands');
    ->save();
-   
+
 $newsItem->name; // Returns 'Name in English' given that the current app locale is 'en'
 $newsItem->getTranslation('name', 'nl'); // returns 'Naam in het Nederlands'
 
@@ -75,7 +75,7 @@ use Spatie\Translatable\HasTranslations;
 class NewsItem extends Model
 {
     use HasTranslations;
-    
+
     public $translatable = ['name'];
 }
 ```
@@ -179,6 +179,16 @@ In laravel 5.2.23 and above you can use the fluent syntax:
 
 ```php
 NewsItem::where('name->en', 'Name in English')->get();
+```
+
+If you don't specify any locale, the current app's locale will be used:
+
+```php
+app()->setLocale('en');
+NewsItem::where('name', 'Name in English')->get();
+
+app()->setLocale('nl');
+NewsItem::whereName('Naam in het Nederlands')->firstOrFail();
 ```
 
 ## Changelog

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -173,4 +173,16 @@ class TranslatableTest extends TestCase
 
         $this->assertEquals($testModel->name, 'I just mutated testValue_en');
     }
+
+    /** @test */
+    public function it_can_query_eloquent_with_or_without_specified_locale()
+    {
+        $this->testModel->setTranslation('name', 'en', 'testValue');
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+        $this->testModel->save();
+
+        app()->setLocale('fr');
+        $this->assertSame('testValue', TestModel::where('name->en', 'testValue')->first()->name);
+        $this->assertSame('testValue_fr', TestModel::where('name', 'testValue_fr')->first()->name);
+    }
 }


### PR DESCRIPTION
Instead of refactoring all my controllers in order to being able to query models implementing your awesome translatable trait, I tried to override the `Model::__call` method.

Now, I can easily get my models based on their translated names :

```php
$doc = \App\Document::where('name', $name)->firstOrFail();
```

the `__call` method checks if the requested column is a translatable one. If yes, and does not contain any locale specification, the current app's locale is automatically added and sent back to the query builder.

That was really simple until I tried to deal with the `dynamicWhere` backward compliance, but it works well.

I also added a test but it fails as it requires a real MySQL 5.7 server instead of an sqlite database and I did not want to commit my modified `TestCase.php` (which is not generic or clean)