### PR TITLE
add setAttribute for stright storing values for translatable attribute

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -29,7 +29,7 @@ trait HasTranslations
      */
     public function setAttribute($key, $value)
     {
-        if (!$this->isTranslatableAttribute($key, $value)) {
+        if (!$this->isTranslatableAttribute($key)) {
             return parent::setAttribute($key, $value);
         }
 

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -23,6 +23,28 @@ trait HasTranslations
     }
 
     /**
+     * @param $key
+     * @param $value
+     * @return HasTranslations|void
+     */
+    public function setAttribute($key, $value)
+    {
+        if (!$this->isTranslatableAttribute($key, $value)) {
+            return parent::setAttribute($key, $value);
+        }
+
+        if (!$value) {
+            return;
+        }
+        
+        if(!json_decode($value)) {
+           return $this->setTranslation($key, config('app.locale'), $value);
+        }
+        
+        return $this->setTranslations($key, json_decode($value, true));
+    }
+
+    /**
      * @param string $key
      * @param string $locale
      *

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -33,15 +33,12 @@ trait HasTranslations
             return parent::setAttribute($key, $value);
         }
 
-        if (!$value) {
-            return;
+        if (is_string($value)) {
+            var_export(['is_string', $value]);
+            return $this->setTranslation($key, config('app.locale'), $value);
         }
-        
-        if(!json_decode($value)) {
-           return $this->setTranslation($key, config('app.locale'), $value);
-        }
-        
-        return $this->setTranslations($key, json_decode($value, true));
+
+        return parent::setAttribute($key, $value);
     }
 
     /**

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -34,7 +34,6 @@ trait HasTranslations
         }
 
         if (is_string($value)) {
-            var_export(['is_string', $value]);
             return $this->setTranslation($key, config('app.locale'), $value);
         }
 


### PR DESCRIPTION
Sometimes need to use attribute assignment without known translations, ex. at model mass assignment very uncomfortable provide whole structure of translation object.

I try to patch Model::setAttribute method to overcome this issue