### PR TITLE
Handle attribute set in all scenarios

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -23,6 +23,30 @@ trait HasTranslations
     }
 
     /**
+	 * @param $key
+	 * @param $value
+	 *
+	 * @return $this
+	 */
+    public function setAttribute($key, $value)
+    {
+        if (!$this->isTranslatableAttribute($key)) {
+            return parent::setAttribute($key, $value);
+        }
+
+        if (is_string($value) && !json_decode($value))
+        {
+            return $this->setTranslation($key, config('app.locale'), $value);
+        }
+	    
+	    if(is_string($value) && json_decode($value)) {
+            return $this->setTranslations($key, json_decode($value, true));
+        }
+        
+        return $value;
+    }
+
+    /**
      * @param string $key
      * @param string $locale
      *


### PR DESCRIPTION
This will save a translatable attribute in the right way.

**Case 1: The attribute value is a string**

Will be se a translation for the current locale.

**Case 2: The attribute value is an array**

Is already in the right form.

**Case 3: JSON encoded string**

Will be decoded and the translations will be set.
