### PR TITLE
Make isTranslatableAttribute() public

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -129,7 +129,7 @@ trait HasTranslations
         return array_keys($this->getTranslations($key));
     }
 
-    protected function isTranslatableAttribute(string $key) : bool
+    public function isTranslatableAttribute(string $key) : bool
     {
         return in_array($key, $this->getTranslatableAttributes());
     }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -181,4 +181,12 @@ class TranslatableTest extends TestCase
 
         $this->assertEquals($translations, $this->testModel->getTranslations('name'));
     }
+
+    /** @test */
+    public function it_can_check_if_an_attribute_is_translatable()
+    {
+        $this->assertTrue($this->testModel->isTranslatableAttribute('name'));
+
+        $this->assertFalse($this->testModel->isTranslatableAttribute('other'));
+    }
 }


### PR DESCRIPTION
I stumbled upon the case where I need to check if an attribute is translatable, e.g.:

```php
$attribute = 'name'; // Defined elsewhere dynamically.

if ($model->isTranslatableAttribute($attribute)) {
   // Do something here...
}
```

I can do the check manually using `getTranslatedAttributes()` but in the end I'd just have a copy of `isTranslatableAttribute()`... So let's expose it..