### PR TITLE
Assume default local when setting attributes with __set

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -23,6 +23,23 @@ trait HasTranslations
     }
 
     /**
+     * Assume default locale for translatable attributes.
+     *
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return $this
+     */
+    public function __set($key, $value)
+    {
+        if (!$this->isTranslatableAttribute($key)) {
+            return $this->setAttribute($key, $value);
+        }
+
+        return $this->setTranslation($key, config('app.locale'), $value);
+    }
+
+    /**
      * @param string $key
      * @param string $locale
      *

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -172,6 +172,28 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_be_set_with_magic_setter_method()
+    {
+        $model = TestModel::create([
+            'name' => [
+                'en' => 'testValue_en',
+                'fr' => 'testValue_fr',
+            ],
+        ]);
+
+        app()->setLocale('en');
+
+        $model->name = 'updated_en';
+        $this->assertEquals('updated_en', $model->name);
+        $this->assertEquals('testValue_fr', $model->getTranslation('name', 'fr'));
+
+        app()->setLocale('fr');
+        $model->name = 'updated_fr';
+        $this->assertEquals('updated_fr', $model->name);
+        $this->assertEquals('updated_en', $model->getTranslation('name', 'en'));
+    }
+
+    /** @test */
     public function it_can_set_multiple_translations_at_once()
     {
         $translations = ['nl' => 'hallo', 'en' => 'hello', 'kh' => 'សួរស្តី'];


### PR DESCRIPTION
To make the package easy to integrate with existing/legacy projects, this PR allows the standard eloquent syntax `$model->key = $value` to set values for the default locale.

