### PR TITLE
Added ability to get the item in a certain locale

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -8,6 +8,8 @@ use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
 trait HasTranslations
 {
+    public $locale = false;
+    
     /**
      * @param string $key
      *
@@ -143,6 +145,11 @@ trait HasTranslations
 
     protected function normalizeLocale(string $key, string $locale) : string
     {
+        // if a locale has been set on the model, use that
+        if ($this->locale) {
+            return $this->locale;
+        }
+        
         if (in_array($locale, $this->getTranslatedLocales($key))) {
             return $locale;
         }
@@ -152,6 +159,17 @@ trait HasTranslations
         }
 
         return $locale;
+    }
+    
+    /**
+     * Set the locale property. Used in normalizeLocale() to force the translation
+     * to a different language that the one set in app()->getLocale();
+     *
+     * @param string $locale
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
     }
 
     public function getTranslatableAttributes() : array

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -147,7 +147,7 @@ trait HasTranslations
     {
         // if a locale has been set on the model, use that
         if ($this->locale) {
-            return $this->locale;
+            $locale = $this->locale;
         }
         
         if (in_array($locale, $this->getTranslatedLocales($key))) {

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -77,6 +77,19 @@ class TranslatableTest extends TestCase
 
         $this->assertSame('testValue_fr', $this->testModel->name);
     }
+    
+    /** @test */
+    public function it_will_return_the_value_with_the_forced_locale_when_using_the_locale_property()
+    {
+        app()->setLocale('en');
+        $this->testModel->setTranslation('name', 'en', 'testValue');
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+        $this->testModel->save();
+        
+        $this->testModel->setLocale('fr');
+        
+        $this->assertSame('testValue_fr', $this->testModel->name);
+    }
 
     /** @test */
     public function it_can_get_all_translations_in_one_go()


### PR DESCRIPTION
I think I've stumbled upon an untreated use case:
- app()->getLocale() is "en";
- but you want to show the item translated in "nl";

[ different reasons; say... you want to show all translations to the user ]

This PR will allow us to do:
```php
app()->setLocale('en');
$newsItem = new NewsItem; // This is an Eloquent model
$newsItem
   ->setTranslation('name', 'en', 'Name in English');
   ->setTranslation('name', 'nl', 'Naam in het Nederlands');
   ->save();
$newsItem->setLocale('nl'); // $newsItem->locale = 'nl'; also works
$newsItem->name; // Returns 'Naam in het Nederlands' given that the forced locale is 'nl'
// does not force the locale on any other page elements
```

**What do you think? Could this make it into the repository** as-is or do you think there's a better way?

----

Details on my reasoning:


I've found no way to cover this use case (please correct me if I'm wrong):
- not by doing ```app()->setLocale()``` to one language, then to another (I tried);
- not by overwriting the ```find()``` and ```findOrFail()``` methods (I tried);

I think the solution I've found is pretty elegant:
- the trait would bring in a new property, ```$locale```;
- we use that property to "force" a certain translation (ignore the translation in ```app->getLocale()```;