### PR TITLE
Set a default translation for the translatable attr.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ before_script:
 
 script:
   - phpunit --coverage-text --coverage-clover=coverage.clover
-
+ 
 after_script:
   - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -24,6 +24,21 @@ trait HasTranslations
 
     /**
      * @param string $key
+     * @param string $value
+     *
+     * @return mixed
+     */
+    public function setAttribute($key, $value)
+    {
+        if (!$this->isTranslatableAttribute($key)) {
+            return parent::setAttribute($key, $value);
+        }
+
+        return $this->setTranslation($key, config('app.locale'), $value);
+    }
+
+    /**
+     * @param string $key
      * @param string $locale
      *
      * @return mixed

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -84,7 +84,7 @@ class TranslatableTest extends TestCase
     public function it_can_set_translated_values_when_creating_a_model()
     {
         $model = TestModel::create([
-            'name' => ['en' => 'testValue_en'],
+            'name' => 'testValue_en',
         ]);
 
         $this->assertSame('testValue_en', $model->name);

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -139,16 +139,20 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_can_forget_a_translation()
     {
+        var_dump( $this->testModel->getTranslations('name'));
+        
         $this->testModel->setTranslation('name', 'en', 'testValue_en');
         $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
         $this->testModel->save();
-
+var_dump( $this->testModel->getTranslations('name')
         $this->assertSame([
             'en' => 'testValue_en',
             'fr' => 'testValue_fr',
         ], $this->testModel->getTranslations('name'));
 
+         var_dump( $this->testModel->getTranslations('name'));
         $this->testModel->forgetTranslation('name', 'en');
+         var_dump( $this->testModel->getTranslations('name'));
 
         $this->assertSame([
             'fr' => 'testValue_fr',


### PR DESCRIPTION
This PR is aimed to provide setter functionality for default translatable fields. Without this method, when you want to save an Eloquent model, `HasTranslations` trait is appliying `"` on the fields and not converting them to json. So this `setAttribute `method will automatically convert to json column when saving the model without required to call `setTranslation `method