### PR TITLE
Set a default translation for the translatable attr

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -37,7 +37,7 @@ trait HasTranslations
         if (is_string($value) && !json_decode($value)) {
             return $this->setTranslation($key, config('app.locale'), $value);
         }
-       
+
         if (is_string($value) && json_decode($value)) {
             return $this->setTranslations($key, json_decode($value, true));
         }

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -34,7 +34,17 @@ trait HasTranslations
             return parent::setAttribute($key, $value);
         }
 
-        return $this->setTranslation($key, config('app.locale'), $value);
+        if (is_string($value) && !json_decode($value))
+        {
+             return $this->setTranslation($key, config('app.locale'), $value);
+        }
+       
+        if(is_string($value) && json_decode($value)) 
+        {
+             return $this->setTranslations($key, json_decode($value, true));
+        }
+
+        return $value;
     }
 
     /**

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -34,14 +34,12 @@ trait HasTranslations
             return parent::setAttribute($key, $value);
         }
 
-        if (is_string($value) && !json_decode($value))
-        {
-             return $this->setTranslation($key, config('app.locale'), $value);
+        if (is_string($value) && !json_decode($value)) {
+            return $this->setTranslation($key, config('app.locale'), $value);
         }
        
-        if(is_string($value) && json_decode($value)) 
-        {
-             return $this->setTranslations($key, json_decode($value, true));
+        if (is_string($value) && json_decode($value)) {
+            return $this->setTranslations($key, json_decode($value, true));
         }
 
         return $value;

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -24,6 +24,21 @@ trait HasTranslations
 
     /**
      * @param string $key
+     * @param string $value
+     *
+     * @return mixed
+     */
+    public function setAttribute($key, $value)
+    {
+        if (!$this->isTranslatableAttribute($key)) {
+            return parent::setAttribute($key, $value);
+        }
+
+        return $this->setTranslation($key, config('app.locale'), $value);
+    }
+
+    /**
+     * @param string $key
      * @param string $locale
      *
      * @return mixed
@@ -130,7 +145,7 @@ trait HasTranslations
 
         unset($translations[$locale]);
 
-        $this->setAttribute($key, $translations);
+        $this->attributes[$key] = $this->asJson($translations);
 
         return $this;
     }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -84,7 +84,7 @@ class TranslatableTest extends TestCase
     public function it_can_set_translated_values_when_creating_a_model()
     {
         $model = TestModel::create([
-            'name' => ['en' => 'testValue_en'],
+            'name' => 'testValue_en',
         ]);
 
         $this->assertSame('testValue_en', $model->name);


### PR DESCRIPTION
This PR is aimed to provide setter functionality for default translatable fields. Without this method, when you want to save an Eloquent model, `HasTranslations` trait is appliying `"` on the fields and not converting them to json. So this `setAttribute `method will automatically convert to json column based on app.lang when saving the model without required to call `setTranslation` method