### PR TITLE
New feature : set locale only for model

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -8,6 +8,29 @@ use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
 trait HasTranslations
 {
+    protected $modelLocale = null;
+
+    /**
+     * @param string $locale
+     *
+     * @return $this
+     */
+    public function setModelLocale(string $locale = '')
+    {
+        $this->modelLocale = $locale;
+        return $this;
+    }
+
+    /**
+     *
+     * @return $this
+     */
+    public function forgetModelLocale()
+    {
+        $this->modelLocale = null;
+        return $this;
+    }
+
     /**
      * @param string $key
      *
@@ -19,7 +42,7 @@ trait HasTranslations
             return parent::getAttributeValue($key);
         }
 
-        return $this->getTranslation($key, config('app.locale'));
+        return $this->getTranslation($key, is_null($this->modelLocale) ? config('app.locale') : $this->modelLocale);
     }
 
     /**


### PR DESCRIPTION
Hi all,
I'm building a translation interface for my current project.

It's quite simple : i have a model translatable in english an french.
And the interface itself is also translated with the built in feature in Laravel.

I wanted to be able to edit the french translation of my model in english web interface. As the form in view is handled with laravel-form-builder library, i tried to found a laravel-translatable way to do it it well, because the model is stick to the locale app.

With my modifications, i’m able to edit models with this kind of routes /{locale}/translate/model/{lang}/

If locale is **en** and lang is **fr** , my interface is in english and my model is in french.

```
        $model = MyModel::find($id);
        $model->setModelLocale($lang);
        // do want you want with another lang configured in app locale
```

So i think it is as small improvement.