### PR TITLE
Return translated values when calling ToArray() on model

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -183,4 +183,20 @@ trait HasTranslations
             array_fill_keys($this->getTranslatableAttributes(), 'array')
         );
     }
+
+    /**
+     * Convert the model instance to an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $attributes = parent::toArray();
+
+        foreach ($this->getTranslatableAttributes() as $field) {
+            $attributes[$field] = $this->getTranslation($field, config('app.locale'));
+        }
+
+        return $attributes;
+    }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -224,4 +224,17 @@ class TranslatableTest extends TestCase
 
         $this->assertFalse($this->testModel->isTranslatableAttribute('other'));
     }
+
+    /** @test */
+    public function it_can_return_translated_attributes_as_array()
+    {
+        $this->testModel->setTranslation('name', 'en', 'testValue');
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+        $this->testModel->save();
+
+        app()->setLocale('fr');
+
+        $attributes = $this->testModel->toArray();
+        $this->assertSame('testValue_fr', $attributes['name']);
+    }
 }


### PR DESCRIPTION
Like discussed in Issue #47 I needed to use the translated model as JSON. So I've added the ToArray() support. Feel free to decline the PR, if you think that it won't be used by others.