### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,13 @@
         }
     ],
     "require": {
-        "php" : "^7.0",
-        "illuminate/database": "~5.3.0|~5.4.0",
-        "illuminate/support": "~5.3.0|~5.4.0"
+        "php": "^7.0",
+        "illuminate/database": "~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*",
-        "orchestra/testbench": "~3.3.0|~3.4.0",
+        "phpunit/phpunit": "^6.2",
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev",
         "mockery/mockery": "^0.9.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/database": "~5.3.0|~5.4.0|~5.5.x-dev",
-        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev"
+        "illuminate/database": "~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",
-        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev",
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev|~3.5.x-dev",
         "mockery/mockery": "^0.9.4"
     },
     "autoload": {
@@ -65,3 +65,4 @@
         }
     }
 }
+


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-translatable/phpunit.xml.dist

....................                                              20 / 20 (100%)

Time: 4.06 seconds, Memory: 12.00MB

OK (20 tests, 26 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments