### PR TITLE
Retrieve first translation if no current or fallback

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -19,7 +19,7 @@ trait HasTranslations
             return parent::getAttributeValue($key);
         }
 
-        return $this->getTranslation($key, config('app.locale'));
+        return $this->getTranslation($key, config('app.locale')) ?: array_first($this->getTranslations($key));
     }
 
     /**


### PR DESCRIPTION
In case both default/current and fallback translations doesn't exist, make sure to return first existing translation of the translatable field. This make sure to return a value rather than an empty string.