### PR TITLE
Support for setting a translation directly through the property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-translatable` will be documented in this file
 
+## [Unreleased]
+- added support for setting a translation directly through the property (e.g. `$item->name = 'New translation';`)
+
 ## 2.0.0 - 2017-08-30
 
 - added support for Laravel 5.5, dropped support for all older versions

--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ public function getTranslation(string $attributeName, string $locale) : string
 This function has an alias named `translate`.
 
 #### Setting a translation
+The easiest way to set a translation for the current locale is to just set the property for a translatable attribute.
+For example (given that `name` is a translatable attribute):
+
+```php
+$newsItem->name = 'New translation';
+```
+
+To set a translation for a specific locale you can use this method:
 
 ``` php
 public function setTranslation(string $attributeName, string $locale, string $value)

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -33,7 +33,7 @@ trait HasTranslations
     public function setAttribute($key, $value)
     {
         // pass arrays and untranslatable attributes to the parent method
-        if (!$this->isTranslatableAttribute($key) or is_array($value)) {
+        if (!$this->isTranslatableAttribute($key) || is_array($value)) {
             return parent::setAttribute($key, $value);
         }
         // if the attribute is translatable and not already translated (=array),

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -23,6 +23,24 @@ trait HasTranslations
     }
 
     /**
+     * Set a given attribute on the model.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function setAttribute($key, $value)
+    {
+        // pass arrays and untranslateable attributes to the parent method
+        if (!$this->isTranslatableAttribute($key) or is_array($value)) {
+            return parent::setAttribute($key, $value);
+        }
+        // if the attribute is translateable and not already translated (=array),
+        // set a translation for the current app locale
+        return $this->setTranslation($key, config('app.locale'), $value);
+    }
+
+    /**
      * @param string $key
      * @param string $locale
      *

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -31,11 +31,11 @@ trait HasTranslations
      */
     public function setAttribute($key, $value)
     {
-        // pass arrays and untranslateable attributes to the parent method
+        // pass arrays and untranslatable attributes to the parent method
         if (!$this->isTranslatableAttribute($key) or is_array($value)) {
             return parent::setAttribute($key, $value);
         }
-        // if the attribute is translateable and not already translated (=array),
+        // if the attribute is translatable and not already translated (=array),
         // set a translation for the current app locale
         return $this->setTranslation($key, config('app.locale'), $value);
     }

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -25,8 +25,9 @@ trait HasTranslations
     /**
      * Set a given attribute on the model.
      *
-     * @param  string  $key
-     * @param  mixed  $value
+     * @param string $key
+     * @param mixed  $value
+     *
      * @return $this
      */
     public function setAttribute($key, $value)

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -238,6 +238,28 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_translations_for_default_language()
+    {
+        $model = TestModel::create([
+            'name' => [
+                'en' => 'testValue_en',
+                'fr' => 'testValue_fr',
+            ],
+        ]);
+
+        app()->setLocale('en');
+
+        $model->name = 'updated_en';
+        $this->assertEquals('updated_en', $model->name);
+        $this->assertEquals('testValue_fr', $model->getTranslation('name', 'fr'));
+
+        app()->setLocale('fr');
+        $model->name = 'updated_fr';
+        $this->assertEquals('updated_fr', $model->name);
+        $this->assertEquals('updated_en', $model->getTranslation('name', 'en'));
+    }
+
+    /** @test */
     public function it_can_set_multiple_translations_at_once()
     {
         $translations = ['nl' => 'hallo', 'en' => 'hello', 'kh' => 'សួរស្តី'];


### PR DESCRIPTION
I reused some of bbrother's code from the PR #21 to realize the possibility to set translations with the default eloquent syntax (`$model->key = 'Translation';`) without using magic methods.

If a user sets a translation this way, the current app locale is used to save the translation (as it is already the case for getting translations).

