### PR TITLE
getTranslations($key) is not always returning an array

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -88,7 +88,7 @@ trait HasTranslations
     {
         $this->guardAgainstUntranslatableAttribute($key);
 
-        return json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true);
+        return json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?? [];
     }
 
     /**


### PR DESCRIPTION
json_decode not always returns an array and getTranslaction signature need an array to be returned.

I suggest returning an empty array if json_decode has failed or throwing some custom Exception that the application can catch and decide what to do.

I am working with data saved in old legacy database that, in some records, the json data is not valid. It is not a big issue, so we could just render some "info not available right now". Now, the app is crashing.

I can create my own Trait expanding this one, but maybe you want to value another solution.

Cheers