### PR TITLE
Predefine the asJson method so it preserves unicode chars

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -121,6 +121,19 @@ trait HasTranslations
     }
 
     /**
+     * Casts the passed value to json
+     * preserving the unicode chars
+     *
+     * @param array $value
+     *
+     * @return string
+     */
+    protected function asJson($value)
+    {
+        return json_encode($value, JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
      * @param string $key
      * @param array  $translations
      *

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -122,7 +122,7 @@ trait HasTranslations
 
     /**
      * Casts the passed value to json
-     * preserving the unicode chars
+     * preserving the unicode chars.
      *
      * @param array $value
      *


### PR DESCRIPTION
I predefined the asJson method of the Model, so the translated fields are casted to json without excapting unicode characters, so they could be searched in the database, with like statements for example.