### PR TITLE
It can translate a field based on the translations of another one

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -108,7 +108,7 @@ trait HasTranslations
 
         if ($this->hasSetMutator($key)) {
             $method = 'set'.Str::studly($key).'Attribute';
-            $this->{$method}($value);
+            $this->{$method}($value, $locale);
             $value = $this->attributes[$key];
         }
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -340,14 +340,14 @@ class TranslatableTest extends TestCase
 
         $testModel->setTranslations('other_field', [
             'nl' => 'hallo',
-            'en' => 'hello',
+            'en' => 'hello'
         ]);
 
         $testModel->save();
 
         $expected = [
             'nl' => 'hallo wereld',
-            'en' => 'hello world',
+            'en' => 'hello world'
         ];
 
         $this->assertEquals($expected, $testModel->getTranslations('other_field'));

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -322,4 +322,34 @@ class TranslatableTest extends TestCase
 
         $this->assertEquals($expected, $testModel->getTranslations('name'));
     }
+
+    /** @test */
+    public function it_can_translate_a_field_based_on_the_translations_of_another_one()
+    {
+        $testModel = (new class() extends TestModel {
+            public function setOtherFieldAttribute($value, $locale = 'en')
+            {
+                $this->attributes['other_field'] = $value.' '.$this->getTranslation('name', $locale);
+            }
+        });
+
+        $testModel->setTranslations('name', [
+            'nl' => 'wereld',
+            'en' => 'world'
+        ]);
+
+        $testModel->setTranslations('other_field', [
+            'nl' => 'hallo',
+            'en' => 'hello',
+        ]);
+
+        $testModel->save();
+
+        $expected = [
+            'nl' => 'hallo wereld',
+            'en' => 'hello world',
+        ];
+
+        $this->assertEquals($expected, $testModel->getTranslations('other_field'));
+    }
 }


### PR DESCRIPTION
In addition to my previous PR on mutators, I was thinking about this feature request.

Sometimes, when I set a field using a mutator, I need to use another field in this mutator. But if this another field is also a translatable field, it does not works as expected.
 
I wrote a test to generally explain that. But here's a "real world" example :

```php
class BlogPost extends Model
{
    use HasTranslations;

    protected $translatable = ['title', 'slug'];

    public function setSlugAttribute($slug, $locale = 'en')
    {
        if (!$slug) {
            $slug = $this->getTranslation('title', $locale);
        }
        $this->attributes['slug'] = str_slug($slug);
    }
}
```

Given the name is set to something like `['en' => 'Hello world', 'fr' => 'Bonjour le monde']` and the slug is null, then the slug will be set to `['en' => 'hello-world', 'fr' => 'bonjour-le-monde']`

What do you think about this feature ?