### PR TITLE
Replace config('app.locale') with getLocale()

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -19,7 +19,7 @@ trait HasTranslations
             return parent::getAttributeValue($key);
         }
 
-        return $this->getTranslation($key, config('app.locale'));
+        return $this->getTranslation($key, $this->getLocale());
     }
 
     /**
@@ -38,7 +38,7 @@ trait HasTranslations
         }
         // if the attribute is translatable and not already translated (=array),
         // set a translation for the current app locale
-        return $this->setTranslation($key, config('app.locale'), $value);
+        return $this->setTranslation($key, $this->getLocale(), $value);
     }
 
     /**
@@ -194,6 +194,11 @@ trait HasTranslations
         }
 
         return $locale;
+    }
+
+    protected function getLocale() : string
+    {
+        return config('app.locale');
     }
 
     public function getTranslatableAttributes() : array


### PR DESCRIPTION
This would allow for better extensibility in other packages. An example I'm having in mind, is [Backpack's HasTranslations trait](https://github.com/Laravel-Backpack/CRUD/blob/master/src/ModelTraits/SpatieTranslatable/HasTranslations.php).