### PR TITLE
Handle when json field is encoded null

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -88,7 +88,7 @@ trait HasTranslations
     {
         $this->guardAgainstUntranslatableAttribute($key);
 
-        return json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true);
+        return json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [];
     }
 
     /**

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -352,4 +352,20 @@ class TranslatableTest extends TestCase
 
         $this->assertEquals($expected, $testModel->getTranslations('other_field'));
     }
+
+    /** @test */
+    public function it_handle_null_value_from_database()
+    {
+        $testModel = (new class() extends TestModel {
+            public function setAttributesExternally(array $attributes)
+            {
+                $this->attributes = $attributes;
+            }
+        });
+
+        $testModel->setAttributesExternally(['name' => json_encode(null), 'other_field' => null]);
+
+        $this->assertEquals('', $testModel->name);
+        $this->assertEquals('', $testModel->other_field);
+    }
 }


### PR DESCRIPTION
I had to create migration to add json not null columns to a table.
After that all values are set to `null` which is valid json, so after decoding it value was null, but array was expected.

This is just handling that situation.