### PR TITLE
Add getAllTranslations()

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ public function getTranslation(string $attributeName, string $locale) : string
 
 This function has an alias named `translate`.
 
+#### Getting all translations
+
+The easiest way to get all translations for all translatable attributes at the same time is to just use the `getAllTranslations()` method:
+
+```php
+$newsItem->getAllTranslations();
+```
+
 #### Setting a translation
 The easiest way to set a translation for the current locale is to just set the property for a translatable attribute.
 For example (given that `name` is a translatable attribute):

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -91,6 +91,18 @@ trait HasTranslations
         return json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [];
     }
 
+    public function getAllTranslations() : array
+    {
+        $translations = [];
+
+        foreach ($this->getTranslatableAttributes() as $attribute) {
+            $this->guardAgainstUntranslatableAttribute($attribute);
+            $translations[$attribute] = json_decode($this->getAttributes()[$attribute] ?? '' ?: '{}') ?: [];
+        }
+
+        return json_decode(json_encode($translations), true);
+    }
+
     /**
      * @param string $key
      * @param string $locale

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -87,14 +87,12 @@ trait HasTranslations
     public function getTranslations($key = null) : array
     {
         if ($key !== null) {
-
             $this->guardAgainstUntranslatableAttribute($key);
 
             return json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [];
         }
 
         return array_reduce($this->getTranslatableAttributes(), function ($result, $item) {
-
             $result[$item] = $this->getTranslations($item);
 
             return $result;

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -84,23 +84,21 @@ trait HasTranslations
         return $this->getTranslation($key, $locale, false);
     }
 
-    public function getTranslations($key) : array
+    public function getTranslations($key = null) : array
     {
-        $this->guardAgainstUntranslatableAttribute($key);
+        if ($key !== null) {
 
-        return json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [];
-    }
+            $this->guardAgainstUntranslatableAttribute($key);
 
-    public function getAllTranslations() : array
-    {
-        $translations = [];
-
-        foreach ($this->getTranslatableAttributes() as $attribute) {
-            $this->guardAgainstUntranslatableAttribute($attribute);
-            $translations[$attribute] = json_decode($this->getAttributes()[$attribute] ?? '' ?: '{}') ?: [];
+            return json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [];
         }
 
-        return json_decode(json_encode($translations), true);
+        return array_reduce($this->getTranslatableAttributes(), function ($result, $item) {
+
+            $result[$item] = $this->getTranslations($item);
+
+            return $result;
+        });
     }
 
     /**

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -127,6 +127,28 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_all_translations_for_all_translatable_attributes_in_one_go()
+    {
+        $this->testModel->setTranslation('name', 'en', 'testValue_en');
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+
+        $this->testModel->setTranslation('other_field', 'en', 'testValue_en');
+        $this->testModel->setTranslation('other_field', 'fr', 'testValue_fr');
+        $this->testModel->save();
+
+        $this->assertSame([
+            'name' => [
+                'en' => 'testValue_en',
+                'fr' => 'testValue_fr',
+            ],
+            'other_field' => [
+                'en' => 'testValue_en',
+                'fr' => 'testValue_fr',
+            ]
+        ], $this->testModel->getAllTranslations());
+    }
+
+    /** @test */
     public function it_can_get_the_locales_which_have_a_translation()
     {
         $this->testModel->setTranslation('name', 'en', 'testValue_en');

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -144,7 +144,7 @@ class TranslatableTest extends TestCase
             'other_field' => [
                 'en' => 'testValue_en',
                 'fr' => 'testValue_fr',
-            ]
+            ],
         ], $this->testModel->getAllTranslations());
     }
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -145,7 +145,7 @@ class TranslatableTest extends TestCase
                 'en' => 'testValue_en',
                 'fr' => 'testValue_fr',
             ],
-        ], $this->testModel->getAllTranslations());
+        ], $this->testModel->getTranslations());
     }
 
     /** @test */


### PR DESCRIPTION
Added a method called `getAllTranslations` to return every translatable field and the possible values. This is valuable because when creating a UI to edit translations, having each language and all it's values returned at the same time is much easier to deal with than looping and requesting each attribute/key and language that's being used.