### PR TITLE
Add getTranslationsAttribute accessor

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -209,7 +209,7 @@ trait HasTranslations
             : [];
     }
 
-    public function getTranslationsAttribute()
+    public function getTranslationsAttribute(): array
     {
         return collect($this->getTranslatableAttributes())
             ->mapWithKeys(function (string $key) {

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -209,6 +209,15 @@ trait HasTranslations
             : [];
     }
 
+    public function getTranslationsAttribute()
+    {
+        return collect($this->getTranslatableAttributes())
+            ->mapWithKeys(function (string $key) {
+                return [$key => $this->getTranslations($key)];
+            })
+            ->toArray();
+    }
+
     public function getCasts() : array
     {
         return array_merge(


### PR DESCRIPTION
This is required to get the Nova tool working. The name is way too generic though. I say we either use a more "technical" name, or release a new major version. Maybe revisit some other things while we're at it?