### PR TITLE
Filter empty/null translations

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -64,7 +64,7 @@ trait HasTranslations
         if ($key !== null) {
             $this->guardAgainstNonTranslatableAttribute($key);
 
-            return json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [];
+            return array_filter(json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: []);
         }
 
         return array_reduce($this->getTranslatableAttributes(), function ($result, $item) {

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -404,4 +404,16 @@ class TranslatableTest extends TestCase
            'other_field' => [],
         ], $this->testModel->translations);
     }
+
+    /** @test */
+    public function it_will_return_fallback_locale_translation_when_getting_an_empty_translation_from_the_locale()
+    {
+        $this->app['config']->set('laravel-translatable.fallback_locale', 'en');
+
+        $this->testModel->setTranslation('name', 'en', 'testValue_en');
+        $this->testModel->setTranslation('name', 'nl', null);
+        $this->testModel->save();
+
+        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'nl'));
+    }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -19,7 +19,7 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_will_return_fallback_locale_translation_when_getting_an_unknown_locale()
     {
-        $this->app['config']->set('laravel-translatable.fallback_locale', 'en');
+        $this->app['config']->set('translatable.fallback_locale', 'en');
 
         $this->testModel->setTranslation('name', 'en', 'testValue_en');
         $this->testModel->save();
@@ -30,7 +30,7 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_provides_a_flog_to_not_return_fallback_locale_translation_when_getting_an_unknown_locale()
     {
-        $this->app['config']->set('laravel-translatable.fallback_locale', 'en');
+        $this->app['config']->set('translatable.fallback_locale', 'en');
 
         $this->testModel->setTranslation('name', 'en', 'testValue_en');
         $this->testModel->save();
@@ -41,7 +41,7 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_will_return_fallback_locale_translation_when_getting_an_unknown_locale_and_fallback_is_true()
     {
-        $this->app['config']->set('laravel-translatable.fallback_locale', 'en');
+        $this->app['config']->set('translatable.fallback_locale', 'en');
 
         $this->testModel->setTranslation('name', 'en', 'testValue_en');
         $this->testModel->save();
@@ -52,7 +52,7 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_will_return_an_empty_string_when_getting_an_unknown_locale_and_fallback_is_not_set()
     {
-        $this->app['config']->set('laravel-translatable.fallback_locale', '');
+        $this->app['config']->set('translatable.fallback_locale', '');
 
         $this->testModel->setTranslation('name', 'en', 'testValue_en');
         $this->testModel->save();
@@ -408,7 +408,7 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_will_return_fallback_locale_translation_when_getting_an_empty_translation_from_the_locale()
     {
-        $this->app['config']->set('laravel-translatable.fallback_locale', 'en');
+        $this->app['config']->set('translatable.fallback_locale', 'en');
 
         $this->testModel->setTranslation('name', 'en', 'testValue_en');
         $this->testModel->setTranslation('name', 'nl', null);


### PR DESCRIPTION
Why I think this should be merged:

I've a form with 4 input fields:
```
<input type="text" name="name[nl]">
<input type="text" name="name[en]">
<input type="text" name="name[de]">
<input type="text" name="name[fr]">
```

When I submit the form and won't fill the English translation it will be saved like this in the DB:
```
{"de": "DE", "en": null, "fr": "FR", "nl": "NL"}
```

So when I change the locale to English I'm not getting anything because it's null. It should fallback to the fallback locale (in my case NL) because I've set so.

In this PR I'm filtering out those empty translations so the fallback is working.