### PR TITLE
Allow translation of "array" fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,19 @@ $translations = [
 $newsItem->setTranslations('name', $translations);
 ```
 
+You can also set all translations in one go by setting the value of the respective propery to an array containing all translations.
+
+**Note: This does not work if the attribute has a cast to `array` declared. In that case, you will always set the translation for the current locale, when setting the property directly.**
+
+Example:
+
+``` php
+$newsItem->name = [
+   'en' => 'Name in English',
+   'nl' => 'Naam in het Nederlands'
+];
+```
+
 ### Events
 
 #### TranslationHasBeenSet

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -20,7 +20,9 @@ trait HasTranslations
     public function setAttribute($key, $value)
     {
         // Pass arrays and untranslatable attributes to the parent method.
-        if (! $this->isTranslatableAttribute($key) || is_array($value)) {
+        if (! $this->isTranslatableAttribute($key) ||
+            (is_array($value) && ! $this->shouldCastToArray($key))
+        ) {
             return parent::setAttribute($key, $value);
         }
 
@@ -29,12 +31,19 @@ trait HasTranslations
         return $this->setTranslation($key, $this->getLocale(), $value);
     }
 
+    protected function shouldCastToArray(string $attribute): bool
+    {
+        $originalCasts = parent::getCasts($attribute);
+
+        return array_key_exists($attribute, $originalCasts) && $originalCasts[$attribute] === 'array';
+    }
+
     public function translate(string $key, string $locale = ''): string
     {
         return $this->getTranslation($key, $locale);
     }
 
-    public function getTranslation(string $key, string $locale, bool $useFallbackLocale = true): string
+    public function getTranslation(string $key, string $locale, bool $useFallbackLocale = true)
     {
         $locale = $this->normalizeLocale($key, $locale, $useFallbackLocale);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,6 +27,7 @@ abstract class TestCase extends Orchestra
             $table->increments('id');
             $table->text('name')->nullable();
             $table->text('other_field')->nullable();
+            $table->text('array_field')->nullable();
         });
     }
 }

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -12,7 +12,10 @@ class TestModel extends Model
     protected $table = 'test_models';
 
     protected $guarded = [];
+    protected $casts = [
+        'array_field' => 'array',
+    ];
     public $timestamps = false;
 
-    public $translatable = ['name', 'other_field'];
+    public $translatable = ['name', 'other_field', 'array_field'];
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -313,7 +313,7 @@ class TranslatableTest extends TestCase
     {
         $translations = [
             'nl' => ['testValue_1_nl', 'testValue_2_nl'],
-            'en' => ['testValue_1_en', 'testValue_2_en']
+            'en' => ['testValue_1_en', 'testValue_2_en'],
         ];
 
         $this->testModel->setTranslations('array_field', $translations);
@@ -329,7 +329,7 @@ class TranslatableTest extends TestCase
         $this->testModel->save();
 
         $this->assertEquals([
-            $this->app->getLocale() => ['testValue_1', 'testValue_2']
+            $this->app->getLocale() => ['testValue_1', 'testValue_2'],
         ], $this->testModel->getTranslations('array_field'));
     }
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -81,6 +81,15 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_save_a_translated_attribute_that_is_cast_to_array()
+    {
+        $this->testModel->setTranslation('array_field', 'en', ['testValue_1_en', 'testValue_2_en']);
+        $this->testModel->save();
+
+        $this->assertSame(['testValue_1_en', 'testValue_2_en'], $this->testModel->array_field);
+    }
+
+    /** @test */
     public function it_can_set_translated_values_when_creating_a_model()
     {
         $model = TestModel::create([
@@ -134,6 +143,9 @@ class TranslatableTest extends TestCase
 
         $this->testModel->setTranslation('other_field', 'en', 'testValue_en');
         $this->testModel->setTranslation('other_field', 'fr', 'testValue_fr');
+
+        $this->testModel->setTranslation('array_field', 'en', ['testValue_1_en', 'testValue_2_en']);
+        $this->testModel->setTranslation('array_field', 'fr', ['testValue_1_fr', 'testValue_2_fr']);
         $this->testModel->save();
 
         $this->assertSame([
@@ -144,6 +156,10 @@ class TranslatableTest extends TestCase
             'other_field' => [
                 'en' => 'testValue_en',
                 'fr' => 'testValue_fr',
+            ],
+            'array_field' => [
+                'en' => ['testValue_1_en', 'testValue_2_en'],
+                'fr' => ['testValue_1_fr', 'testValue_2_fr'],
             ],
         ], $this->testModel->getTranslations());
     }
@@ -293,6 +309,31 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_multiple_translations_at_once_on_an_attribute_with_array_cast()
+    {
+        $translations = [
+            'nl' => ['testValue_1_nl', 'testValue_2_nl'],
+            'en' => ['testValue_1_en', 'testValue_2_en']
+        ];
+
+        $this->testModel->setTranslations('array_field', $translations);
+        $this->testModel->save();
+
+        $this->assertEquals($translations, $this->testModel->getTranslations('array_field'));
+    }
+
+    /** @test */
+    public function it_can_not_set_multiple_translations_at_once_on_an_attribute_with_array_cast_when_directly_setting_the_property()
+    {
+        $this->testModel->array_field = ['testValue_1', 'testValue_2'];
+        $this->testModel->save();
+
+        $this->assertEquals([
+            $this->app->getLocale() => ['testValue_1', 'testValue_2']
+        ], $this->testModel->getTranslations('array_field'));
+    }
+
+    /** @test */
     public function it_can_check_if_an_attribute_is_translatable()
     {
         $this->assertTrue($this->testModel->isTranslatableAttribute('name'));
@@ -402,6 +443,7 @@ class TranslatableTest extends TestCase
         $this->assertEquals([
            'name' => ['nl' => 'hallo', 'en' => 'hello'],
            'other_field' => [],
+           'array_field' => [],
         ], $this->testModel->translations);
     }
 


### PR DESCRIPTION
This is an attempt to allow translations for arrays. To make this work, two things were necessary:
1) Remove the return type hint of `string` from the `getTranslation()` method
2) Refactor the `is_array()` check in `setAttribute()` that defers to parent::setAttribute() when the value is an array

In consequence of 2) it would become impossible to set all translations directly by setting the value of an attribute to an array. Therefore i've introduced a check against the models' `casts` property to only pass through to `parent::setAttribute()` if the attribute is not declared as "cast to array".

This should preserve all previous behaviour with basic strings. It only introduces the limitation that one has to use `setTranslations()` in order to set all translation of an array cast attribute.