### PR TITLE
Add support for storing unescaped Unicode in DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This is the contents of the published file:
 ```php
 return [
   'fallback_locale' => 'en',
+  'unescaped_unicode' => false,
 ];
 ```
 

--- a/config/translatable.php
+++ b/config/translatable.php
@@ -6,4 +6,9 @@ return [
      * If a translation has not been set for a given locale, use this locale instead.
      */
     'fallback_locale' => 'en',
+
+    /*
+     * Whether to escape unicode characters when storing in DB.
+     */
+    'unescaped_unicode' => false,
 ];

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -92,7 +92,10 @@ trait HasTranslations
 
         $translations[$locale] = $value;
 
-        $this->attributes[$key] = $this->asJson($translations);
+		if (config('translatable.unescaped_unicode'))
+			$this->attributes[$key] = json_encode($translations, JSON_UNESCAPED_UNICODE);
+		else
+			$this->attributes[$key] = $this->asJson($translations);
 
         event(new TranslationHasBeenSet($this, $key, $locale, $oldValue, $value));
 


### PR DESCRIPTION
This is a fix for #134 

It defaults to the original behavior, so existing code shouldn't break or be affected at all. This PR simply adds an option to workaround the issue.

This is important for searching through Unicode characters using `LIKE` query.
