### PR TITLE
[Fixed breaking change] Added support for translating non-text attributes

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -34,7 +34,7 @@ trait HasTranslations
         return $this->getTranslation($key, $locale);
     }
 
-    public function getTranslation(string $key, string $locale, bool $useFallbackLocale = true): string
+    public function getTranslation(string $key, string $locale, bool $useFallbackLocale = true)
     {
         $locale = $this->normalizeLocale($key, $locale, $useFallbackLocale);
 


### PR DESCRIPTION
In short:
- in version 2.x, ```getTranslation()``` could return an array/object;
- in version 3.x, the result for ```getTranslation()``` must be an array;

**Removing this constraint allows developers to use this package for translating non-text attributes**. It fixes the only breaking change I've encountered when moving from 2.x to 3.x, while breaking _nothing_ in the current version.

Even if you did not intend for developers to use your package to translate non-text attributes, I'd say forcing the result to ```array``` brings no value. While removing it allow _some_ developers to keep using your package, to translate strings, arrays, objects, whatever they want.

What do you think - too strict of a constraint here?

PS. This issue was also mentioned by @promatik in https://github.com/spatie/laravel-translatable/pull/135#issuecomment-434275504 and https://github.com/spatie/laravel-translatable/issues/115#issuecomment-433616480 