### PR TITLE
Allow 0 to be used a translation value

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -64,7 +64,9 @@ trait HasTranslations
         if ($key !== null) {
             $this->guardAgainstNonTranslatableAttribute($key);
 
-            return array_filter(json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: []);
+            return array_filter(json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [], function($value) {
+                return ($value !== null && $value !== false && $value !== '');
+            });
         }
 
         return array_reduce($this->getTranslatableAttributes(), function ($result, $item) {

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -416,4 +416,37 @@ class TranslatableTest extends TestCase
 
         $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'nl'));
     }
+
+    /** @test */
+    public function it_will_return_correct_translation_value_if_value_is_set_to_zero()
+    {
+        $this->testModel->setTranslation('name', 'nl', '0');
+        $this->testModel->save();
+
+        $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
+    }
+
+    /** @test */
+    public function it_will_not_return_fallback_value_if_value_is_set_to_zero()
+    {
+        $this->app['config']->set('translatable.fallback_locale', 'en');
+
+        $this->testModel->setTranslation('name', 'en', '1');
+        $this->testModel->setTranslation('name', 'nl', '0');
+        $this->testModel->save();
+
+        $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
+    }
+
+    /** @test */
+    public function it_will_not_remove_zero_value_of_other_locale_in_database()
+    {
+        $this->app['config']->set('translatable.fallback_locale', 'en');
+
+        $this->testModel->setTranslation('name', 'nl', '0');
+        $this->testModel->setTranslation('name', 'en', '1');
+        $this->testModel->save();
+
+        $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
+    }
 }


### PR DESCRIPTION
This is a fix for #143.

All values that PHP evaluates to 'false' were not returned, including 0. This PR will make sure that only empty strings and missing translations are stripped from the result.

As this is my first PR, please let me know if more information is needed.

Thank you.