### PR TITLE
Fix: Remove the provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,12 +55,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Spatie\\Translatable\\TranslatableServiceProvider"
-            ]
-        }
     }
 }


### PR DESCRIPTION
The provider is no longer required.

Laravel 5.8 is throwing errors while installing this (v4.1) package -
```
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

In ProviderRepository.php line 208:
                                                                     
  Class 'Spatie\Translatable\TranslatableServiceProvider' not found  
                                                                     

Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```