### PR TITLE
Allow false or true values in translations

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -65,7 +65,7 @@ trait HasTranslations
             $this->guardAgainstNonTranslatableAttribute($key);
 
             return array_filter(json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [], function ($value) {
-                return $value !== null && $value !== false && $value !== '';
+                return $value !== null && $value !== '';
             });
         }
 


### PR DESCRIPTION
Applicable when trying to set active on one translation, but inactive on another.