### PR TITLE
Add test for storing unescaped Unicode in DB

### DIFF
--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -461,4 +461,18 @@ class TranslatableTest extends TestCase
 
         $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
     }
+
+    /** @test */
+    public function it_will_store_unescaped_unicode_in_database()
+    {
+        $this->app['config']->set('app.fallback_locale', 'en');
+        $this->app['config']->set('translatable.unescaped_unicode', true);
+
+        $this->testModel->setTranslation('name', 'zh', '空间');
+        $this->testModel->save();
+
+        $this->assertDatabaseHas('test_models', ['name' => '{"zh":"空间"}']);
+        $this->assertDatabaseMissing('test_models', ['name' => '{"zh":"\u7a7a\u95f4"}']);
+    }
+
 }


### PR DESCRIPTION
This adds a test for the PR in #136 .