### PR TITLE
Only include required illuminate dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     ],
     "require": {
         "php" : "^7.2",
-        "laravel/framework": "~5.8.0"
+        "illuminate/database": "~5.8.0",
+        "illuminate/support": "~5.8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -3,6 +3,7 @@
 namespace Spatie\Translatable;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Config;
 use Spatie\Translatable\Events\TranslationHasBeenSet;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
@@ -166,7 +167,7 @@ trait HasTranslations
             return $locale;
         }
 
-        if (! is_null($fallbackLocale = config('app.fallback_locale'))) {
+        if (! is_null($fallbackLocale = Config::get('app.fallback_locale'))) {
             return $fallbackLocale;
         }
 
@@ -175,7 +176,7 @@ trait HasTranslations
 
     protected function getLocale() : string
     {
-        return config('app.locale');
+        return Config::get('app.locale');
     }
 
     public function getTranslatableAttributes() : array


### PR DESCRIPTION
Since I am using this package in a non-laravel-framework environment I don't need to have the whole framework installed.

This PR updates the composer dependencies to only include `illuminate/database` and `illuminate/support`.

I've also had to update the `config()` references since the helper is defined in `illuminate/foundation`.
Additionally I've added the `.phpunit.result.cache` to the `.gitignore` file

Thanks for this handy package 🙂 