### PR TITLE
modify where on translatable columns automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 .phpunit.result.cache
+.idea/

--- a/src/Events/TranslationHasBeenSet.php
+++ b/src/Events/TranslationHasBeenSet.php
@@ -18,6 +18,14 @@ class TranslationHasBeenSet
     public $oldValue;
     public $newValue;
 
+    /**
+     * TranslationHasBeenSet constructor.
+     * @param Model $model
+     * @param string $key
+     * @param string $locale
+     * @param $oldValue
+     * @param $newValue
+     */
     public function __construct(Model $model, string $key, string $locale, $oldValue, $newValue)
     {
         $this->model = $model;

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -4,11 +4,22 @@ namespace Spatie\Translatable;
 
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Config;
+use Spatie\Translatable\Scopes\WhereScope;
 use Spatie\Translatable\Events\TranslationHasBeenSet;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
 trait HasTranslations
 {
+    /**
+     * The "booting" method of the model.
+     *
+     * @return void
+     */
+    protected static function bootHasTranslations()
+    {
+        static::addGlobalScope(new WhereScope);
+    }
+
     /**
      * @param $key
      * @return string

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -9,6 +9,10 @@ use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
 trait HasTranslations
 {
+    /**
+     * @param $key
+     * @return string
+     */
     public function getAttributeValue($key)
     {
         if (! $this->isTranslatableAttribute($key)) {
@@ -18,6 +22,11 @@ trait HasTranslations
         return $this->getTranslation($key, $this->getLocale());
     }
 
+    /**
+     * @param $key
+     * @param $value
+     * @return HasTranslations
+     */
     public function setAttribute($key, $value)
     {
         // Pass arrays and untranslatable attributes to the parent method.
@@ -30,11 +39,23 @@ trait HasTranslations
         return $this->setTranslation($key, $this->getLocale(), $value);
     }
 
+    /**
+     * @param string $key
+     * @param string $locale
+     * @param bool $useFallbackLocale
+     * @return string
+     */
     public function translate(string $key, string $locale = '', bool $useFallbackLocale = true): string
     {
         return $this->getTranslation($key, $locale, $useFallbackLocale);
     }
 
+    /**
+     * @param string $key
+     * @param string $locale
+     * @param bool $useFallbackLocale
+     * @return string
+     */
     public function getTranslation(string $key, string $locale, bool $useFallbackLocale = true)
     {
         $locale = $this->normalizeLocale($key, $locale, $useFallbackLocale);
@@ -50,16 +71,30 @@ trait HasTranslations
         return $translation;
     }
 
+    /**
+     * @param string $key
+     * @param string $locale
+     * @return string
+     */
     public function getTranslationWithFallback(string $key, string $locale): string
     {
         return $this->getTranslation($key, $locale, true);
     }
 
+    /**
+     * @param string $key
+     * @param string $locale
+     * @return string
+     */
     public function getTranslationWithoutFallback(string $key, string $locale)
     {
         return $this->getTranslation($key, $locale, false);
     }
 
+    /**
+     * @param string|null $key
+     * @return array
+     */
     public function getTranslations(string $key = null) : array
     {
         if ($key !== null) {
@@ -77,6 +112,12 @@ trait HasTranslations
         });
     }
 
+    /**
+     * @param string $key
+     * @param string $locale
+     * @param $value
+     * @return HasTranslations
+     */
     public function setTranslation(string $key, string $locale, $value): self
     {
         $this->guardAgainstNonTranslatableAttribute($key);
@@ -102,6 +143,11 @@ trait HasTranslations
         return $this;
     }
 
+    /**
+     * @param string $key
+     * @param array $translations
+     * @return HasTranslations
+     */
     public function setTranslations(string $key, array $translations): self
     {
         $this->guardAgainstNonTranslatableAttribute($key);
@@ -113,6 +159,11 @@ trait HasTranslations
         return $this;
     }
 
+    /**
+     * @param string $key
+     * @param string $locale
+     * @return HasTranslations
+     */
     public function forgetTranslation(string $key, string $locale): self
     {
         $translations = $this->getTranslations($key);
@@ -124,6 +175,10 @@ trait HasTranslations
         return $this;
     }
 
+    /**
+     * @param string $locale
+     * @return HasTranslations
+     */
     public function forgetAllTranslations(string $locale): self
     {
         collect($this->getTranslatableAttributes())->each(function (string $attribute) use ($locale) {
@@ -133,16 +188,29 @@ trait HasTranslations
         return $this;
     }
 
+    /**
+     * @param string $key
+     * @return array
+     */
     public function getTranslatedLocales(string $key) : array
     {
         return array_keys($this->getTranslations($key));
     }
 
+    /**
+     * @param string $key
+     * @return bool
+     */
     public function isTranslatableAttribute(string $key) : bool
     {
         return in_array($key, $this->getTranslatableAttributes());
     }
 
+    /**
+     * @param string $key
+     * @param string|null $locale
+     * @return bool
+     */
     public function hasTranslation(string $key, string $locale = null): bool
     {
         $locale = $locale ?: $this->getLocale();
@@ -150,6 +218,9 @@ trait HasTranslations
         return isset($this->getTranslations($key)[$locale]);
     }
 
+    /**
+     * @param string $key
+     */
     protected function guardAgainstNonTranslatableAttribute(string $key)
     {
         if (! $this->isTranslatableAttribute($key)) {
@@ -157,6 +228,12 @@ trait HasTranslations
         }
     }
 
+    /**
+     * @param string $key
+     * @param string $locale
+     * @param bool $useFallbackLocale
+     * @return string
+     */
     protected function normalizeLocale(string $key, string $locale, bool $useFallbackLocale) : string
     {
         if (in_array($locale, $this->getTranslatedLocales($key))) {
@@ -178,11 +255,17 @@ trait HasTranslations
         return $locale;
     }
 
+    /**
+     * @return string
+     */
     protected function getLocale() : string
     {
         return Config::get('app.locale');
     }
 
+    /**
+     * @return array
+     */
     public function getTranslatableAttributes() : array
     {
         return is_array($this->translatable)
@@ -190,6 +273,9 @@ trait HasTranslations
             : [];
     }
 
+    /**
+     * @return array
+     */
     public function getTranslationsAttribute(): array
     {
         return collect($this->getTranslatableAttributes())
@@ -199,6 +285,9 @@ trait HasTranslations
             ->toArray();
     }
 
+    /**
+     * @return array
+     */
     public function getCasts() : array
     {
         return array_merge(

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -26,7 +26,7 @@ trait HasTranslations
      */
     public function getAttributeValue($key)
     {
-        if (! $this->isTranslatableAttribute($key)) {
+        if (!$this->isTranslatableAttribute($key)) {
             return parent::getAttributeValue($key);
         }
 
@@ -41,7 +41,7 @@ trait HasTranslations
     public function setAttribute($key, $value)
     {
         // Pass arrays and untranslatable attributes to the parent method.
-        if (! $this->isTranslatableAttribute($key) || is_array($value)) {
+        if (!$this->isTranslatableAttribute($key) || is_array($value)) {
             return parent::setAttribute($key, $value);
         }
 
@@ -106,7 +106,7 @@ trait HasTranslations
      * @param string|null $key
      * @return array
      */
-    public function getTranslations(string $key = null) : array
+    public function getTranslations(string $key = null): array
     {
         if ($key !== null) {
             $this->guardAgainstNonTranslatableAttribute($key);
@@ -138,7 +138,7 @@ trait HasTranslations
         $oldValue = $translations[$locale] ?? '';
 
         if ($this->hasSetMutator($key)) {
-            $method = 'set'.Str::studly($key).'Attribute';
+            $method = 'set' . Str::studly($key) . 'Attribute';
 
             $this->{$method}($value, $locale);
 
@@ -203,7 +203,7 @@ trait HasTranslations
      * @param string $key
      * @return array
      */
-    public function getTranslatedLocales(string $key) : array
+    public function getTranslatedLocales(string $key): array
     {
         return array_keys($this->getTranslations($key));
     }
@@ -212,7 +212,7 @@ trait HasTranslations
      * @param string $key
      * @return bool
      */
-    public function isTranslatableAttribute(string $key) : bool
+    public function isTranslatableAttribute(string $key): bool
     {
         return in_array($key, $this->getTranslatableAttributes());
     }
@@ -234,7 +234,7 @@ trait HasTranslations
      */
     protected function guardAgainstNonTranslatableAttribute(string $key)
     {
-        if (! $this->isTranslatableAttribute($key)) {
+        if (!$this->isTranslatableAttribute($key)) {
             throw AttributeIsNotTranslatable::make($key, $this);
         }
     }
@@ -245,21 +245,21 @@ trait HasTranslations
      * @param bool $useFallbackLocale
      * @return string
      */
-    protected function normalizeLocale(string $key, string $locale, bool $useFallbackLocale) : string
+    protected function normalizeLocale(string $key, string $locale, bool $useFallbackLocale): string
     {
         if (in_array($locale, $this->getTranslatedLocales($key))) {
             return $locale;
         }
 
-        if (! $useFallbackLocale) {
+        if (!$useFallbackLocale) {
             return $locale;
         }
 
-        if (! is_null($fallbackLocale = Config::get('translatable.fallback_locale'))) {
+        if (!is_null($fallbackLocale = Config::get('translatable.fallback_locale'))) {
             return $fallbackLocale;
         }
 
-        if (! is_null($fallbackLocale = Config::get('app.fallback_locale'))) {
+        if (!is_null($fallbackLocale = Config::get('app.fallback_locale'))) {
             return $fallbackLocale;
         }
 
@@ -269,7 +269,7 @@ trait HasTranslations
     /**
      * @return string
      */
-    protected function getLocale() : string
+    protected function getLocale(): string
     {
         return Config::get('app.locale');
     }
@@ -277,7 +277,7 @@ trait HasTranslations
     /**
      * @return array
      */
-    public function getTranslatableAttributes() : array
+    public function getTranslatableAttributes(): array
     {
         return is_array($this->translatable)
             ? $this->translatable
@@ -299,7 +299,7 @@ trait HasTranslations
     /**
      * @return array
      */
-    public function getCasts() : array
+    public function getCasts(): array
     {
         return array_merge(
             parent::getCasts(),

--- a/src/Scopes/WhereScope.php
+++ b/src/Scopes/WhereScope.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Translatable\Scopes;
 
-use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Database\Eloquent\Builder;
 
 class WhereScope implements Scope
@@ -11,13 +11,13 @@ class WhereScope implements Scope
     /**
      * Apply the scope to a given Eloquent query builder.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Builder $builder
+     * @param  \Illuminate\Database\Eloquent\Model $model
      * @return void
      */
     public function apply(Builder $builder, Model $model)
     {
-        $newQuery = $this->changeQuery($builder , $model);
+        $newQuery = $this->changeQuery($builder, $model);
 
         $builder->setQuery($newQuery);
     }
@@ -37,8 +37,8 @@ class WhereScope implements Scope
 
         $newArr = [];
         foreach ($wheres as $key => $where) {
-            if (method_exists($this , "iterateOn" . $where['type'])) {
-                $newArr[] = $this->{"iterateOn" . $where['type']}($where , $translatableColumns , $locale);
+            if (method_exists($this, "iterateOn" . $where['type'])) {
+                $newArr[] = $this->{"iterateOn" . $where['type']}($where, $translatableColumns, $locale);
             } else {
                 $newArr[] = $where;
             }
@@ -57,13 +57,13 @@ class WhereScope implements Scope
      * @param $locale
      * @return mixed
      */
-    private function iterateOnBasic($where , $translatableColumns , $locale)
+    private function iterateOnBasic($where, $translatableColumns, $locale)
     {
         if (
-            array_key_exists('column' , $where) &&
-            in_array($where['column'] , $translatableColumns)
+            array_key_exists('column', $where) &&
+            in_array($where['column'], $translatableColumns)
         ) {
-            $where['column'] = explode('->' , $where['column'])[0] . "->{$locale}";
+            $where['column'] = explode('->', $where['column'])[0] . "->{$locale}";
         }
 
         return $where;
@@ -75,15 +75,15 @@ class WhereScope implements Scope
      * @param $locale
      * @return mixed
      */
-    private function iterateOnNested($where , $translatableColumns , $locale)
+    private function iterateOnNested($where, $translatableColumns, $locale)
     {
         $nestedQuery = $where['query'];
         $nestedWheres = $nestedQuery->wheres;
         $newNestedArr = [];
         foreach ($nestedWheres as $nestedWhere) {
 
-            if (method_exists($this , "iterateOn" . $nestedWhere['type'])) {
-                $newNestedArr [] = $this->{"iterateOn" . $nestedWhere['type']}($nestedWhere , $translatableColumns , $locale);
+            if (method_exists($this, "iterateOn" . $nestedWhere['type'])) {
+                $newNestedArr [] = $this->{"iterateOn" . $nestedWhere['type']}($nestedWhere, $translatableColumns, $locale);
             }
         }
 

--- a/src/Scopes/WhereScope.php
+++ b/src/Scopes/WhereScope.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Spatie\Translatable\Scopes;
+
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class WhereScope implements Scope
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model)
+    {
+        $newQuery = $this->changeQuery($builder , $model);
+
+        $builder->setQuery($newQuery);
+    }
+
+    /**
+     * @param Builder $builder
+     * @param Model $model
+     * @return \Illuminate\Database\Query\Builder
+     */
+    private function changeQuery(Builder $builder, Model $model)
+    {
+        /** @var \Spatie\Translatable\HasTranslations $model */
+        $translatableColumns = $model->getTranslatableAttributes();
+        $query = $builder->getQuery();
+        $wheres = $query->wheres;
+        $locale = app()->getLocale();
+
+        $newArr = [];
+        foreach ($wheres as $key => $where) {
+            if (method_exists($this , "iterateOn" . $where['type'])) {
+                $newArr[] = $this->{"iterateOn" . $where['type']}($where , $translatableColumns , $locale);
+            } else {
+                $newArr[] = $where;
+            }
+        }
+
+        if (!empty($newArr)) {
+            $query->wheres = $newArr;
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param $where
+     * @param $translatableColumns
+     * @param $locale
+     * @return mixed
+     */
+    private function iterateOnBasic($where , $translatableColumns , $locale)
+    {
+        if (
+            array_key_exists('column' , $where) &&
+            in_array($where['column'] , $translatableColumns)
+        ) {
+            $where['column'] = explode('->' , $where['column'])[0] . "->{$locale}";
+        }
+
+        return $where;
+    }
+
+    /**
+     * @param $where
+     * @param $translatableColumns
+     * @param $locale
+     * @return mixed
+     */
+    private function iterateOnNested($where , $translatableColumns , $locale)
+    {
+        $nestedQuery = $where['query'];
+        $nestedWheres = $nestedQuery->wheres;
+        $newNestedArr = [];
+        foreach ($nestedWheres as $nestedWhere) {
+
+            if (method_exists($this , "iterateOn" . $nestedWhere['type'])) {
+                $newNestedArr [] = $this->{"iterateOn" . $nestedWhere['type']}($nestedWhere , $translatableColumns , $locale);
+            }
+        }
+
+        $nestedQuery->wheres = $newNestedArr;
+        $where['query'] = $nestedQuery;
+        return $where;
+    }
+}

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -234,8 +234,9 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_is_compatible_with_accessors_on_non_translatable_attributes()
     {
-        $testModel = new class() extends TestModel {
-            public function getOtherFieldAttribute() : string
+        $testModel = new class() extends TestModel
+        {
+            public function getOtherFieldAttribute(): string
             {
                 return 'accessorName';
             }
@@ -247,8 +248,9 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_can_use_accessors_on_translated_attributes()
     {
-        $testModel = new class() extends TestModel {
-            public function getNameAttribute($value) : string
+        $testModel = new class() extends TestModel
+        {
+            public function getNameAttribute($value): string
             {
                 return "I just accessed {$value}";
             }
@@ -262,7 +264,8 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_can_use_mutators_on_translated_attributes()
     {
-        $testModel = new class() extends TestModel {
+        $testModel = new class() extends TestModel
+        {
             public function setNameAttribute($value)
             {
                 $this->attributes['name'] = "I just mutated {$value}";
@@ -330,7 +333,8 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_can_correctly_set_a_field_when_a_mutator_is_defined()
     {
-        $testModel = (new class() extends TestModel {
+        $testModel = (new class() extends TestModel
+        {
             public function setNameAttribute($value)
             {
                 $this->attributes['name'] = "I just mutated {$value}";
@@ -346,7 +350,8 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_can_set_multiple_translations_when_a_mutator_is_defined()
     {
-        $testModel = (new class() extends TestModel {
+        $testModel = (new class() extends TestModel
+        {
             public function setNameAttribute($value)
             {
                 $this->attributes['name'] = "I just mutated {$value}";
@@ -375,10 +380,11 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_can_translate_a_field_based_on_the_translations_of_another_one()
     {
-        $testModel = (new class() extends TestModel {
+        $testModel = (new class() extends TestModel
+        {
             public function setOtherFieldAttribute($value, $locale = 'en')
             {
-                $this->attributes['other_field'] = $value.' '.$this->getTranslation('name', $locale);
+                $this->attributes['other_field'] = $value . ' ' . $this->getTranslation('name', $locale);
             }
         });
 
@@ -405,7 +411,8 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_handle_null_value_from_database()
     {
-        $testModel = (new class() extends TestModel {
+        $testModel = (new class() extends TestModel
+        {
             public function setAttributesExternally(array $attributes)
             {
                 $this->attributes = $attributes;
@@ -427,8 +434,8 @@ class TranslatableTest extends TestCase
         $this->testModel->save();
 
         $this->assertEquals([
-           'name' => ['nl' => 'hallo', 'en' => 'hello'],
-           'other_field' => [],
+            'name' => ['nl' => 'hallo', 'en' => 'hello'],
+            'other_field' => [],
         ], $this->testModel->translations);
     }
 
@@ -483,10 +490,11 @@ class TranslatableTest extends TestCase
         $locale = 'en';
         app()->setLocale($locale);
 
-        $modelQuery = TestModel::where('name' , 'LIKE' , "%test%")->toSql();
+        $modelQuery = TestModel::where('name', 'LIKE', "%test%")->toSql();
 
-        $this->assertTrue(Str::contains($modelQuery , "'$.\"{$locale}\"'"));
+        $this->assertTrue(Str::contains($modelQuery, "'$.\"{$locale}\"'"));
     }
+
     /** @test */
     public function it_will_add_locale_to_query_automatically_and_will_returns_result()
     {
@@ -494,8 +502,8 @@ class TranslatableTest extends TestCase
             'name' => ['en' => 'testValue_en'],
         ]);
 
-        $count = TestModel::where('name' , 'LIKE' , "%test%")->count();
+        $count = TestModel::where('name', 'LIKE', "%test%")->count();
 
-        $this->assertEquals(1 , $count);
+        $this->assertEquals(1, $count);
     }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -487,4 +487,15 @@ class TranslatableTest extends TestCase
 
         $this->assertTrue(Str::contains($modelQuery , "'$.\"{$locale}\"'"));
     }
+    /** @test */
+    public function it_will_add_locale_to_query_automatically_and_will_returns_result()
+    {
+        TestModel::create([
+            'name' => ['en' => 'testValue_en'],
+        ]);
+
+        $count = TestModel::where('name' , 'LIKE' , "%test%")->count();
+
+        $this->assertEquals(1 , $count);
+    }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Translatable\Test;
 
+use Illuminate\Support\Str;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
 class TranslatableTest extends TestCase
@@ -474,5 +475,16 @@ class TranslatableTest extends TestCase
         $this->testModel->save();
 
         $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
+    }
+
+    /** @test */
+    public function it_will_add_locale_to_query_automatically()
+    {
+        $locale = 'en';
+        app()->setLocale($locale);
+
+        $modelQuery = TestModel::where('name' , 'LIKE' , "%test%")->toSql();
+
+        $this->assertTrue(Str::contains($modelQuery , "'$.\"{$locale}\"'"));
     }
 }


### PR DESCRIPTION
it would be very nice if developer not have to modify all their queries and base code from scratch

this patch will add a global scope to all translatable models
to modify their queries on runtime for sake of fast developing ! :)

any advice would be appreciated !