### PR TITLE
Support HasAttributes, not Model

### DIFF
--- a/src/Events/TranslationHasBeenSet.php
+++ b/src/Events/TranslationHasBeenSet.php
@@ -18,7 +18,7 @@ class TranslationHasBeenSet
     public $oldValue;
     public $newValue;
 
-    public function __construct(Model $model, string $key, string $locale, $oldValue, $newValue)
+    public function __construct($model, string $key, string $locale, $oldValue, $newValue)
     {
         $this->model = $model;
 

--- a/src/Events/TranslationHasBeenSet.php
+++ b/src/Events/TranslationHasBeenSet.php
@@ -2,8 +2,6 @@
 
 namespace Spatie\Translatable\Events;
 
-use Illuminate\Database\Eloquent\Model;
-
 class TranslationHasBeenSet
 {
     /** @var \Spatie\Translatable\Translatable */

--- a/src/Exceptions/AttributeIsNotTranslatable.php
+++ b/src/Exceptions/AttributeIsNotTranslatable.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class AttributeIsNotTranslatable extends Exception
 {
-    public static function make(string $key, Model $model)
+    public static function make(string $key, $model)
     {
         $translatableAttributes = implode(', ', $model->getTranslatableAttributes());
 

--- a/src/Exceptions/AttributeIsNotTranslatable.php
+++ b/src/Exceptions/AttributeIsNotTranslatable.php
@@ -3,7 +3,6 @@
 namespace Spatie\Translatable\Exceptions;
 
 use Exception;
-use Illuminate\Database\Eloquent\Model;
 
 class AttributeIsNotTranslatable extends Exception
 {


### PR DESCRIPTION
This removes the constraint of `Model` to allow for any class that `HasAttributes` to `HasTranslatable` as well.

This opens other use cases such as using laravel-translatable inside `Template` classes with [https://github.com/whitecube/nova-page](nova-page).

Thanks!