### PR TITLE
Fix forgetTranslation & forgetAllTranslations on fields with mutator

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -117,9 +117,12 @@ trait HasTranslations
     {
         $translations = $this->getTranslations($key);
 
-        unset($translations[$locale]);
+        unset(
+            $translations[$locale],
+            $this->$key
+        );
 
-        $this->setAttribute($key, $translations);
+        $this->setTranslations($key, $translations);
 
         return $this;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,6 +27,7 @@ abstract class TestCase extends Orchestra
             $table->increments('id');
             $table->text('name')->nullable();
             $table->text('other_field')->nullable();
+            $table->text('field_with_mutator')->nullable();
         });
     }
 }

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -14,5 +14,10 @@ class TestModel extends Model
     protected $guarded = [];
     public $timestamps = false;
 
-    public $translatable = ['name', 'other_field'];
+    public $translatable = ['name', 'other_field', 'field_with_mutator'];
+
+    public function setFieldWithMutatorAttribute($value)
+    {
+        $this->attributes['field_with_mutator'] = $value;
+    }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -148,6 +148,9 @@ class TranslatableTest extends TestCase
 
         $this->testModel->setTranslation('other_field', 'en', 'testValue_en');
         $this->testModel->setTranslation('other_field', 'fr', 'testValue_fr');
+
+        $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
+        $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
         $this->testModel->save();
 
         $this->assertSame([
@@ -156,6 +159,10 @@ class TranslatableTest extends TestCase
                 'fr' => 'testValue_fr',
             ],
             'other_field' => [
+                'en' => 'testValue_en',
+                'fr' => 'testValue_fr',
+            ],
+            'field_with_mutator' => [
                 'en' => 'testValue_en',
                 'fr' => 'testValue_fr',
             ],
@@ -192,6 +199,25 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_forget_a_field_with_mutator_translation()
+    {
+        $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
+        $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
+        $this->testModel->save();
+
+        $this->assertSame([
+            'en' => 'testValue_en',
+            'fr' => 'testValue_fr',
+        ], $this->testModel->getTranslations('field_with_mutator'));
+
+        $this->testModel->forgetTranslation('field_with_mutator', 'en');
+
+        $this->assertSame([
+            'fr' => 'testValue_fr',
+        ], $this->testModel->getTranslations('field_with_mutator'));
+    }
+
+    /** @test */
     public function it_can_forget_all_translations()
     {
         $this->testModel->setTranslation('name', 'en', 'testValue_en');
@@ -199,6 +225,9 @@ class TranslatableTest extends TestCase
 
         $this->testModel->setTranslation('other_field', 'en', 'testValue_en');
         $this->testModel->setTranslation('other_field', 'fr', 'testValue_fr');
+
+        $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
+        $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
         $this->testModel->save();
 
         $this->assertSame([
@@ -211,6 +240,11 @@ class TranslatableTest extends TestCase
             'fr' => 'testValue_fr',
         ], $this->testModel->getTranslations('other_field'));
 
+        $this->assertSame([
+            'en' => 'testValue_en',
+            'fr' => 'testValue_fr',
+        ], $this->testModel->getTranslations('field_with_mutator'));
+
         $this->testModel->forgetAllTranslations('en');
 
         $this->assertSame([
@@ -220,6 +254,10 @@ class TranslatableTest extends TestCase
         $this->assertSame([
             'fr' => 'testValue_fr',
         ], $this->testModel->getTranslations('other_field'));
+
+        $this->assertSame([
+            'fr' => 'testValue_fr',
+        ], $this->testModel->getTranslations('field_with_mutator'));
     }
 
     /** @test */
@@ -423,11 +461,13 @@ class TranslatableTest extends TestCase
         $translations = ['nl' => 'hallo', 'en' => 'hello'];
 
         $this->testModel->setTranslations('name', $translations);
+        $this->testModel->setTranslations('field_with_mutator', $translations);
         $this->testModel->save();
 
         $this->assertEquals([
             'name' => ['nl' => 'hallo', 'en' => 'hello'],
             'other_field' => [],
+            'field_with_mutator' => ['nl' => 'hallo', 'en' => 'hello'],
         ], $this->testModel->translations);
     }
 


### PR DESCRIPTION
This PR will fix bugs on using forgetTranslation & forgetAllTranslations methods on models having mutable fields (as raised in #202).