### PR TITLE
FIX - Use app.fallback_locale by default

### DIFF
--- a/config/translatable.php
+++ b/config/translatable.php
@@ -5,5 +5,5 @@ return [
     /*
      * If a translation has not been set for a given locale, use this locale instead.
      */
-    'fallback_locale' => 'en',
+    'fallback_locale' => null,
 ];


### PR DESCRIPTION
Hello,

Since PR #171, the package uses its default value for "fallback_locale" instead of app value.

Should not it be as follows by default ?

```php
return [
  'fallback_locale' => null,
];
```

Thanks ;)