### PR TITLE
Add possibility to set several translations on Model property

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ For example (given that `name` is a translatable attribute):
 $newsItem->name = 'New translation';
 ```
 
+Also you can set tranlations with
+
+```php
+$newItem->name = ['en' => 'myName', 'nl', 'Naam in het Nederlands'];
+```
+
 To set a translation for a specific locale you can use this method:
 
 ``` php

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -19,7 +19,11 @@ trait HasTranslations
     }
 
     public function setAttribute($key, $value)
-    {
+    {   
+        if ($this->isTranslatableAttribute($key) && is_array($value)) {
+            return $this->setTranslations($key, $value);
+        }
+
         // Pass arrays and untranslatable attributes to the parent method.
         if (! $this->isTranslatableAttribute($key) || is_array($value)) {
             return parent::setAttribute($key, $value);

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -19,7 +19,7 @@ trait HasTranslations
     }
 
     public function setAttribute($key, $value)
-    {   
+    {
         if ($this->isTranslatableAttribute($key) && is_array($value)) {
             return $this->setTranslations($key, $value);
         }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -420,7 +420,7 @@ class TranslatableTest extends TestCase
         $testModel = TestModel::make();
         $testModel->field_with_mutator = $translations;
         $testModel->save();
-        
+
         $this->assertEquals($translations, $testModel->getTranslations('field_with_mutator'));
     }
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -410,6 +410,21 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_multiple_translations_on_field_when_a_mutator_is_defined()
+    {
+        $translations = [
+            'nl' => 'hallo',
+            'en' => 'hello',
+        ];
+
+        $testModel = TestModel::make();
+        $testModel->field_with_mutator = $translations;
+        $testModel->save();
+        
+        $this->assertEquals($translations, $testModel->getTranslations('field_with_mutator'));
+    }
+
+    /** @test */
     public function it_can_translate_a_field_based_on_the_translations_of_another_one()
     {
         $testModel = (new class() extends TestModel {


### PR DESCRIPTION
- Assign multiple translations to field ($model->field = ['en' => 'foo', 'pl' => 'bar']