### PR TITLE
Translate model array attributes

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -17,6 +17,17 @@ trait HasTranslations
 
         return $this->getTranslation($key, $this->getLocale());
     }
+    
+    public function attributesToArray()
+    {
+        $translatedAttributes = collect($this->getTranslatableAttributes())
+            ->mapWithKeys(function (string $key) {
+                return [$key => $this->getAttributeValue($key)];
+            })
+            ->toArray();
+
+        return array_merge(parent::attributesToArray(), $translatedAttributes);
+    }
 
     public function setAttribute($key, $value)
     {


### PR DESCRIPTION
This override the function attributesToArray() of Model for attributes translation.
Now, work with API, instead of receive the value of language types, we only receive value of current language.
Response Ex,
Before:
```
"name": {
    "ja": "ームレスパーカ",
    "en": "This is name"
},
```
And now:
```
"name": "This is name"
```