### PR TITLE
[feature] elegant syntax update

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,27 @@ $translations = [
 $newsItem->setTranslations('name', $translations);
 ```
 
+### Setting the model locale
+The default locale used to translate models is the application locale,
+however it can sometimes be handy to use a custom locale.  
+
+To do so, you can use `setLocale` on a model instance.
+``` php
+$newsItem = NewsItem::firstOrFail()->setLocale('fr');
+
+// Any properties on this model will automaticly be translated in French
+$newsItem->name; // Will return `fr` translation
+$newsItem->name = 'Actualité'; // Will set the `fr` translation
+```
+
+Alternatively, you can use `withLocale` static method:
+``` php
+// Will automatically set the `fr` translation
+$newsItem = NewsItem::withLocale('fr')->create([
+    'name' => 'Actualité',
+]);
+```
+
 ### Events
 
 #### TranslationHasBeenSet

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ $translations = [
 $newsItem->setTranslations('name', $translations);
 ```
 
-### Setting the model locale
+#### Setting the model locale
 The default locale used to translate models is the application locale,
 however it can sometimes be handy to use a custom locale.  
 

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Translatable;
 
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Spatie\Translatable\Events\TranslationHasBeenSet;
@@ -14,11 +13,7 @@ trait HasTranslations
 
     public static function withLocale(string $locale): self
     {
-        $m = new self();
-
-        $m->locale = $locale;
-
-        return $m;
+        return (new self())->setLocale($locale);
     }
 
     public function getAttributeValue($key)
@@ -197,9 +192,16 @@ trait HasTranslations
         return $locale;
     }
 
+    public function setLocale(string $locale): self
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
     public function getLocale(): string
     {
-        return $this->locale ?: App::getLocale();
+        return $this->locale ?: config('app.locale');
     }
 
     public function getTranslatableAttributes(): array

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Translatable;
 
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Spatie\Translatable\Events\TranslationHasBeenSet;
@@ -9,6 +10,17 @@ use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
 trait HasTranslations
 {
+    protected $locale = null;
+
+    public static function withLocale(string $locale): self
+    {
+        $m = new self();
+
+        $m->locale = $locale;
+
+        return $m;
+    }
+
     public function getAttributeValue($key)
     {
         if (! $this->isTranslatableAttribute($key)) {
@@ -185,9 +197,9 @@ trait HasTranslations
         return $locale;
     }
 
-    protected function getLocale(): string
+    public function getLocale(): string
     {
-        return config('app.locale');
+        return $this->locale ?: App::getLocale();
     }
 
     public function getTranslatableAttributes(): array

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -9,7 +9,7 @@ use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
 trait HasTranslations
 {
-    protected $locale = null;
+    protected $translationLocale = null;
 
     public static function withLocale(string $locale): self
     {
@@ -194,14 +194,14 @@ trait HasTranslations
 
     public function setLocale(string $locale): self
     {
-        $this->locale = $locale;
+        $this->translationLocale = $locale;
 
         return $this;
     }
 
     public function getLocale(): string
     {
-        return $this->locale ?: config('app.locale');
+        return $this->translationLocale ?: config('app.locale');
     }
 
     public function getTranslatableAttributes(): array

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -530,4 +530,36 @@ class TranslatableTest extends TestCase
 
         $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
     }
+
+    /** @test */
+    public function it_can_be_translated_based_on_given_locale()
+    {
+        $value = 'World';
+
+        $this->testModel = TestModel::withLocale('en')->fill([
+            'name' => $value,
+        ]);
+        $this->testModel->save();
+
+        $this->assertSame($value, $this->testModel->getTranslation('name', 'en'));
+    }
+
+    /** @test */
+    public function it_can_set_and_fetch_attributes_based_on_set_locale()
+    {
+        $en = 'World';
+        $fr = 'Monde';
+
+        $this->testModel->setLocale('en');
+        $this->testModel->name = $en;
+        $this->testModel->setLocale('fr');
+        $this->testModel->name = $fr;
+
+        $this->testModel->save();
+
+        $this->testModel->setLocale('en');
+        $this->assertSame($en, $this->testModel->name);
+        $this->testModel->setLocale('fr');
+        $this->assertSame($fr, $this->testModel->name);
+    }
 }


### PR DESCRIPTION
This is an attempt at making this package more elegant / easy to use.

The default locale when using the model accessor is the app locale,
In some cases you might need to get / set translations with a custom locale and if you do so the accessor is not usable without overriding the app locale.

In most cases you could just override the app locale for a short period of time but this feels dirty.

Instead of using the app locale this PR adds a `$locale` property on the trait that is used instead of the app locale when set.

That makes it possible to use the accessor with any locale.

Example:
Imagine you want to save some data with the orm through a method:

Model:
``` php
// Model
class Item extends Model
{
    use HasTranslations;

    protected $fillable = ['name', 'info', 'state', 'comment'];

    public $translatable = ['name', 'info'];
}
```

Old way of doing it:
``` php
public function createTranslated($data, $locale)
{
    $test = new Test();

    $test->fill(Arr:except($data, $this->translatable));

    $test->setTranslations($locale, Arr::only($this->translatable))

    $test->save()
}
```

Or

``` php
    public function createTranslated($data, $locale)
    {
        $item = new Item();

        $buff = App::getLocale();
        App::setLocale($locale);

        $item->fill($data);

        $item->save();

        App::setLocale($buff);
    }
```

New way:
``` php
    public function createTranslated($data, $locale)
    {
        Item::withLocale($locale)->create($data);
    }
```

This is just a basic example that shows what issue this PR tries to overcome 