### PR TITLE
Update getTranslations to handle more than one empty translations by key

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -77,7 +77,7 @@ trait HasTranslations
             $this->guardAgainstNonTranslatableAttribute($key);
 
             return array_filter(json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [], function ($value) {
-                return $value !== null && $value !== '';
+                return $value !== null;
             });
         }
 


### PR DESCRIPTION
Before patch: (missing empty translations from SK, NL, only CZ presents)

```
$i->name = ['en'=>'title','hu'=>'cim','fi'=>'fi','nl'=>'','sk'=>'','cz'=>''];
name: "{"en":"title","hu":"cim","fi":"fi","cz":""}"
```

After patch:
```
$i->name = ['en'=>'title','hu'=>'cim','fi'=>'fi','nl'=>'','sk'=>'','cz'=>''];
name: "{"en":"title","hu":"cim","fi":"fi","cz":"","nl":"nl","sk":""}"
```