### PR TITLE
Use string casting for translatable columns

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -235,7 +235,7 @@ trait HasTranslations
     {
         return array_merge(
             parent::getCasts(),
-            array_fill_keys($this->getTranslatableAttributes(), 'array')
+            array_fill_keys($this->getTranslatableAttributes(), 'string')
         );
     }
 }


### PR DESCRIPTION
This PR changes the casts for translatable columns to `string`, as discussed in https://github.com/spatie/laravel-translatable/issues/234.