### PR TITLE
Allow multiple fallback locales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs
 vendor
 .phpunit.result.cache
 .php_cs.cache
+phpunit.xml

--- a/README.md
+++ b/README.md
@@ -51,16 +51,18 @@ return [
   'fallback_locale' => 'en',
 ];
 ```
-Fallback locale might also be an array of fallback locales as such
+Fallback locale might also be an array of fallback locales as such:
 ```php
 return [
   'fallback_locale' => [
-    'defult' => 'en',
+    'default' => 'en',  
     'es' => 'en',
     'ca' => ['es', 'en']
   ],
 ];
 ```
+The array key shall contain the language codes, and values can either be a string of a language code or an array of language codes.
+The special `default` key holds the default fallback locale code that will be used when there is no declared fallback rule for the queried language.
 
 ## Making a model translatable
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ return [
   'fallback_locale' => 'en',
 ];
 ```
+Fallback locale might also be an array of fallback locales as such
+```php
+return [
+  'fallback_locale' => [
+    'defult' => 'en',
+    'es' => 'en',
+    'ca' => ['es', 'en']
+  ],
+];
+```
 
 ## Making a model translatable
 

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -184,7 +184,7 @@ trait HasTranslations
 
     protected function normalizeLocale(string $key, string $locale, bool $useFallbackLocale): string
     {
-        if (in_array($locale, $this->getTranslatedLocales($key))) {
+        if (in_array($locale, $translatedLocales = $this->getTranslatedLocales($key))) {
             return $locale;
         }
 
@@ -193,6 +193,16 @@ trait HasTranslations
         }
 
         if (! is_null($fallbackLocale = config('translatable.fallback_locale'))) {
+            if (is_array($locale)) {
+                if (array_key_exists($locale, $fallbackLocale)) {
+                    if (is_array($fallbackLocale[$locale])) {
+                        return array_intersect($translatedLocales, $fallbackLocale[$locale])[0] ?? $fallbackLocale['default'] ?? config('app.fallback_locale') ?? $locale;
+                    } else {
+                        return $fallbackLocale[$locale];
+                    }
+                }
+            }
+
             return $fallbackLocale;
         }
 

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -193,7 +193,7 @@ trait HasTranslations
         }
 
         if (! is_null($fallbackLocale = config('translatable.fallback_locale'))) {
-            if (is_array($locale)) {
+            if (is_array($fallbackLocale)) {
                 if (array_key_exists($locale, $fallbackLocale)) {
                     if (is_array($fallbackLocale[$locale])) {
                         return array_intersect($translatedLocales, $fallbackLocale[$locale])[0] ?? $fallbackLocale['default'] ?? config('app.fallback_locale') ?? $locale;

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -196,13 +196,16 @@ trait HasTranslations
             if (is_array($fallbackLocale)) {
                 if (array_key_exists($locale, $fallbackLocale)) {
                     if (is_array($fallbackLocale[$locale])) {
-                        return array_intersect($translatedLocales, $fallbackLocale[$locale])[0] ?? $fallbackLocale['default'] ?? config('app.fallback_locale') ?? $locale;
+                        return array_values(array_intersect($fallbackLocale[$locale], $translatedLocales ?? []))[0] ?? $locale;
                     } else {
-                        return $fallbackLocale[$locale];
+                        return $fallbackLocale[$locale] ?? $locale;
                     }
+                } else if(array_key_exists('default', $fallbackLocale)) {
+                    return $fallbackLocale['default'] ?? $locale;
+                } else {
+                    return $locale;
                 }
             }
-
             return $fallbackLocale;
         }
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -29,6 +29,49 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
+    public function it_will_return_package_fallback_locale_translation_when_getting_an_unknown_or_empty_locale()
+    {
+        $this->app['config']->set('translatable.fallback_locale', [
+          'default' => 'en',
+          'es' => 'en',
+          'nl' => ['de', 'en', 'es'],
+          'ca' => ['es', 'en'],
+          'pt' => ['es'],
+          'eu' => null,
+        ]);
+
+        $this->testModel->setTranslation('name', 'en', 'testValue_en');
+        $this->testModel->setTranslation('name', 'nl', 'testValue_nl');
+        $this->testModel->save();
+
+        // With default fallback
+        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'en'));
+        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'de'));
+        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'es'));
+        $this->assertSame('testValue_nl', $this->testModel->getTranslation('name', 'nl'));
+        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'ca'));
+        $this->assertSame('', $this->testModel->getTranslation('name', 'pt'));
+        $this->assertSame('', $this->testModel->getTranslation('name', 'eu'));
+
+        // Without default fallback
+        $this->app['config']->set('translatable.fallback_locale', [
+            'es' => 'en',
+            'nl' => ['de', 'en', 'es'],
+            'ca' => ['es', 'en'],
+            'pt' => ['es'],
+            'eu' => null,
+        ]);
+
+        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'en'));
+        $this->assertSame('', $this->testModel->getTranslation('name', 'de'));
+        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'es'));
+        $this->assertSame('testValue_nl', $this->testModel->getTranslation('name', 'nl'));
+        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'ca'));
+        $this->assertSame('', $this->testModel->getTranslation('name', 'pt'));
+        $this->assertSame('', $this->testModel->getTranslation('name', 'eu'));
+    }
+
+    /** @test */
     public function it_will_return_default_fallback_locale_translation_when_getting_an_unknown_locale()
     {
         $this->app['config']->set('app.fallback_locale', 'en');


### PR DESCRIPTION
Instead of allowing just one locale as a fallback, allow multiple locales based on the queried language (current app language).

This is the contents of the published file:
```php
return [
  'fallback_locale' => 'en',
];
```
Fallback locale might also be an array of fallback locales as such:
```php
return [
  'fallback_locale' => [
    'default' => 'en',  
    'es' => 'en',
    'ca' => ['es', 'en']
  ],
];
```
The array key shall contain the language codes, and values can either be a string of a language code or an array of language codes. The special default key holds the default fallback locale code that will be used when there is no declared fallback rule for the queried language.