### PR TITLE
Clone Translated Model

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -238,4 +238,16 @@ trait HasTranslations
             array_fill_keys($this->getTranslatableAttributes(), 'array')
         );
     }
+
+    public function cloneTranslated(string $locale = '', bool $useFallbackLocale = true): self
+    {
+        $clone = clone $this;
+        $clone->translatable = [];
+
+        collect($this->getTranslatableAttributes())->each(function (string $attribute) use ($clone, $locale, $useFallbackLocale) {
+            $clone->$attribute = $this->getTranslation($attribute, $locale, $useFallbackLocale);
+        });
+
+        return $clone;
+    }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -576,4 +576,20 @@ class TranslatableTest extends TestCase
 
         $this->assertEquals($newTranslations, $this->testModel->getTranslations('name'));
     }
+
+    /** @test */
+    public function it_can_clone_and_translate()
+    {
+        $model = TestModel::create([
+            'name' => [
+                'en' => 'hello',
+                'fr' => 'coucou'
+            ]
+        ]);
+
+        $clonedModel = $model->cloneTranslated('fr');
+        $this->assertSame('coucou', $clonedModel->name);
+        $this->assertSame('hello', $model->getTranslation('name', 'en'));
+        $this->assertSame('coucou', $model->getTranslation('name', 'fr'));
+    }
 }


### PR DESCRIPTION
Aims to return a translated copy of the model.

This PR is a follow-up bringing a solution for the problem brought up in discussion https://github.com/spatie/laravel-translatable/discussions/245, and is a different implementation of the rejected PR https://github.com/spatie/laravel-translatable/pull/222 without breaking changes.

An untranslatable clone is returned. The source remains unaltered.

