### PR TITLE
Add PHP 8-only Support (v5)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,16 +9,14 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0, 7.4]
-                laravel: [8.*, 7.*, 6.*]
+                php: [8.0]
+                laravel: [8.*, 7.*]
                 stability: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 8.*
                         testbench: 6.*
                     -   laravel: 7.*
                         testbench: 5.*
-                    -   laravel: 6.*
-                        testbench: 4.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-translatable` will be documented in this file
 
+## 5.0.0 - unreleased
+
+- require PHP 8+
+- convert syntax to PHP 8
+- drop support for PHP 7.x
+- drop support for Laravel 6.x
+- implement `spatie/laravel-package-tools`
+
 ## 4.6.0 - 2020-11-19
 
 - add support for PHP 8.0 (#241)

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 You can install the package via composer:
 
-``` bash
+```bash
 composer require spatie/laravel-translatable
 ```
 
 If you want to have another fallback_locale than the app fallback locale (see `config/app.php`), you could publish the config file:
-```
+```bash
 php artisan vendor:publish --provider="Spatie\Translatable\TranslatableServiceProvider"
 ```
 
@@ -62,7 +62,7 @@ The required steps to make a model translatable are:
 
 Here's an example of a prepared model:
 
-``` php
+```php
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Translatable\HasTranslations;
 

--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,14 @@
         }
     ],
     "require": {
-        "php" : "^7.2|^8.0",
-        "illuminate/database": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0"
+        "php": "^8.0",
+        "illuminate/database": "^7.0|^8.0",
+        "illuminate/support": "^7.0|^8.0",
+        "spatie/laravel-package-tools": "^1.6"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^4.0|^5.0|^6.0"
+        "orchestra/testbench": "^5.0|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Events/TranslationHasBeenSet.php
+++ b/src/Events/TranslationHasBeenSet.php
@@ -2,15 +2,14 @@
 
 namespace Spatie\Translatable\Events;
 
-use Spatie\Translatable\Translatable;
-
 class TranslationHasBeenSet
 {
-    public function __construct(public mixed $model,
-                                public string $key,
-                                public string $locale,
-                                public mixed $oldValue,
-                                public mixed $newValue,
+    public function __construct(
+        public mixed $model,
+        public string $key,
+        public string $locale,
+        public mixed $oldValue,
+        public mixed $newValue,
     ) {
         //
     }

--- a/src/Events/TranslationHasBeenSet.php
+++ b/src/Events/TranslationHasBeenSet.php
@@ -2,29 +2,16 @@
 
 namespace Spatie\Translatable\Events;
 
+use Spatie\Translatable\Translatable;
+
 class TranslationHasBeenSet
 {
-    /** @var \Spatie\Translatable\Translatable */
-    public $model;
-
-    /** @var string */
-    public $key;
-
-    /** @var string */
-    public $locale;
-
-    public $oldValue;
-    public $newValue;
-
-    public function __construct($model, string $key, string $locale, $oldValue, $newValue)
-    {
-        $this->model = $model;
-
-        $this->key = $key;
-
-        $this->locale = $locale;
-
-        $this->oldValue = $oldValue;
-        $this->newValue = $newValue;
+    public function __construct(public mixed $model,
+                                public string $key,
+                                public string $locale,
+                                public mixed $oldValue,
+                                public mixed $newValue,
+    ) {
+        //
     }
 }

--- a/src/Exceptions/AttributeIsNotTranslatable.php
+++ b/src/Exceptions/AttributeIsNotTranslatable.php
@@ -6,7 +6,7 @@ use Exception;
 
 class AttributeIsNotTranslatable extends Exception
 {
-    public static function make(string $key, $model)
+    public static function make(string $key, $model): static
     {
         $translatableAttributes = implode(', ', $model->getTranslatableAttributes());
 

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -9,14 +9,14 @@ use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
 trait HasTranslations
 {
-    protected $translationLocale = null;
+    protected string | null $translationLocale = null;
 
     public static function usingLocale(string $locale): self
     {
         return (new self())->setLocale($locale);
     }
 
-    public function getAttributeValue($key)
+    public function getAttributeValue($key): mixed
     {
         if (! $this->isTranslatableAttribute($key)) {
             return parent::getAttributeValue($key);
@@ -46,7 +46,7 @@ trait HasTranslations
         return $this->getTranslation($key, $locale, $useFallbackLocale);
     }
 
-    public function getTranslation(string $key, string $locale, bool $useFallbackLocale = true)
+    public function getTranslation(string $key, string $locale, bool $useFallbackLocale = true): mixed
     {
         $locale = $this->normalizeLocale($key, $locale, $useFallbackLocale);
 
@@ -66,7 +66,7 @@ trait HasTranslations
         return $this->getTranslation($key, $locale, true);
     }
 
-    public function getTranslationWithoutFallback(string $key, string $locale)
+    public function getTranslationWithoutFallback(string $key, string $locale): mixed
     {
         return $this->getTranslation($key, $locale, false);
     }
@@ -76,9 +76,10 @@ trait HasTranslations
         if ($key !== null) {
             $this->guardAgainstNonTranslatableAttribute($key);
 
-            return array_filter(json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [], function ($value) {
-                return $value !== null && $value !== '';
-            });
+            return array_filter(
+                json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [],
+                fn ($value) => $value !== null && $value !== ''
+            );
         }
 
         return array_reduce($this->getTranslatableAttributes(), function ($result, $item) {
@@ -175,7 +176,7 @@ trait HasTranslations
         return $this;
     }
 
-    protected function guardAgainstNonTranslatableAttribute(string $key)
+    protected function guardAgainstNonTranslatableAttribute(string $key): void
     {
         if (! $this->isTranslatableAttribute($key)) {
             throw AttributeIsNotTranslatable::make($key, $this);

--- a/src/TranslatableServiceProvider.php
+++ b/src/TranslatableServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Translatable;
 
-use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 class TranslatableServiceProvider extends PackageServiceProvider
 {

--- a/src/TranslatableServiceProvider.php
+++ b/src/TranslatableServiceProvider.php
@@ -2,19 +2,15 @@
 
 namespace Spatie\Translatable;
 
-use Illuminate\Support\ServiceProvider;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\LaravelPackageTools\Package;
 
-class TranslatableServiceProvider extends ServiceProvider
+class TranslatableServiceProvider extends PackageServiceProvider
 {
-    public function boot()
+    public function configurePackage(Package $package): void
     {
-        $this->publishes([
-            __DIR__.'/../config/translatable.php' => config_path('translatable.php'),
-        ], 'config');
-    }
-
-    public function register()
-    {
-        $this->mergeConfigFrom(__DIR__.'/../config/translatable.php', 'translatable');
+        $package
+            ->name('laravel-translatable')
+            ->hasConfigFile();
     }
 }


### PR DESCRIPTION
This PR adds a new major version, v5.0.0.

Specifically, it:

- Removes support for all PHP 7.x versions.
- Requires PHP 8.0+.
- All syntax converted to PHP 8 where possible.
- Removes Laravel v6 support.
- Implements spatie/laravel-package-tools.
- Fixes some minor Readme issues.
- _Updates the changelog - release date needs to be updated, currently is "unreleased"._