### PR TITLE
Fix: return types should match 'mixed' return type of getTranslation

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -41,7 +41,7 @@ trait HasTranslations
         return $this->setTranslation($key, $this->getLocale(), $value);
     }
 
-    public function translate(string $key, string $locale = '', bool $useFallbackLocale = true): string
+    public function translate(string $key, string $locale = '', bool $useFallbackLocale = true): mixed
     {
         return $this->getTranslation($key, $locale, $useFallbackLocale);
     }
@@ -61,7 +61,7 @@ trait HasTranslations
         return $translation;
     }
 
-    public function getTranslationWithFallback(string $key, string $locale): string
+    public function getTranslationWithFallback(string $key, string $locale): mixed
     {
         return $this->getTranslation($key, $locale, true);
     }


### PR DESCRIPTION
I noticed that the `translate` and `getTranslationWithFallback` methods were not updated to return the "mixed" type as per the changes in #269 

I've recently ran into a type error when calling `getTranslationWithFallback` on a Translatable field which has been cast to an `array` on the model.

As `getTranslationWithFallback/translate` return the value that is returned from `getTranslation` the return types should match.