### PR TITLE
added option to save empty attributes as NULL

### DIFF
--- a/config/translatable.php
+++ b/config/translatable.php
@@ -6,4 +6,9 @@ return [
      * If a translation has not been set for a given locale, use this locale instead.
      */
     'fallback_locale' => null,
+    
+    /*
+    * If set to true, will save empty attributes as NULL in the database. if set to false will follow the default behavior.
+    */
+    'save_empty_attributes_as_null' => false,
 ];

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -107,7 +107,12 @@ trait HasTranslations
 
         $translations[$locale] = $value;
 
-        $this->attributes[$key] = $this->asJson($translations);
+        if(!config('translatable.save_empty_attributes_as_null') || count($translations)>1 || $value===0 || $value!=''){
+            $this->attributes[$key] = $this->asJson($translations);
+        }
+        else{
+            $this->attributes[$key] = null;
+        }
 
         event(new TranslationHasBeenSet($this, $key, $locale, $oldValue, $value));
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -576,4 +576,22 @@ class TranslatableTest extends TestCase
 
         $this->assertEquals($newTranslations, $this->testModel->getTranslations('name'));
     }
+
+    /** @test */
+    public function it_will_save_empty_attributes_as_json_in_the_database_by_default()
+    {
+        app()->setLocale('en');
+        $this->testModel->name=null;
+        $this->testModel->save();
+        $this->assertDatabaseHas('test_models',['name'=>'{"en":null}']);
+    }
+
+    /** @test */
+    public function it_will_save_empty_attributes_as_null_in_the_database_when_it_is_configured_to()
+    {
+        config(['translatable.save_empty_attributes_as_null'=>true]);
+        $this->testModel->name=null;
+        $this->testModel->save();
+        $this->assertDatabaseHas('test_models',['name'=>null]);
+    }
 }


### PR DESCRIPTION
this tries to address the problem mentioned in #85
the current behavior for saving an attribute as follows `$model->attribute = null` is to save it as a json object `{"en":null}` in the db assuming that the locale is set to `en`.
I kept the default behavior and added the option `save_empty_attributes_as_null` in the config to save it as  `NULL`.