### PR TITLE
Feature/specify locales in get translations method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $newsItem
    ->setTranslation('name', 'en', 'Name in English')
    ->setTranslation('name', 'nl', 'Naam in het Nederlands')
    ->save();
-   
+
 $newsItem->name; // Returns 'Name in English' given that the current app locale is 'en'
 $newsItem->getTranslation('name', 'nl'); // returns 'Naam in het Nederlands'
 
@@ -69,7 +69,7 @@ use Spatie\Translatable\HasTranslations;
 class NewsItem extends Model
 {
     use HasTranslations;
-    
+
     public $translatable = ['name'];
 }
 ```
@@ -157,6 +157,12 @@ public function forgetAllTranslations(string $locale)
 public function getTranslations(string $attributeName): array
 ```
 
+#### Getting the specified translations in one go
+
+``` php
+public function getTranslations(string $attributeName, array $locales): array
+```
+
 #### Setting translations in one go
 
 ``` php
@@ -198,7 +204,7 @@ $newsItem->getTranslations(); // ['en' => 'hello']
 
 #### Setting the model locale
 The default locale used to translate models is the application locale,
-however it can sometimes be handy to use a custom locale.  
+however it can sometimes be handy to use a custom locale.
 
 To do so, you can use `setLocale` on a model instance.
 ``` php
@@ -296,7 +302,7 @@ trait HasTranslations
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
 
-## Upgrading 
+## Upgrading
 
 ### From v2 to v3
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,24 @@ public function getTranslations(string $attributeName): array
 
 #### Getting the specified translations in one go
 
+You can filter the translations by passing an array of locales:
 ``` php
-public function getTranslations(string $attributeName, array $locales): array
+public function getTranslations(string $attributeName, array $allowedLocales): array
 ```
+
+Here's an example:
+
+```php
+$translations = [
+    'en' => 'Hello',
+    'fr' => 'Bonjour',
+    'de' => 'Hallo',
+];
+
+$newsItem->setTranslations('hello', $translations);
+$newsItem->getTranslations('hello', ['en', 'fr']); // returns ['en' => 'Hello', 'fr' => 'Bonjour']
+```
+
 
 #### Setting translations in one go
 

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -71,20 +71,20 @@ trait HasTranslations
         return $this->getTranslation($key, $locale, false);
     }
 
-    public function getTranslations(string $key = null, array $locales = null): array
+    public function getTranslations(string $key = null, array $allowedLocales = null): array
     {
         if ($key !== null) {
             $this->guardAgainstNonTranslatableAttribute($key);
 
             return array_filter(
                 json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [],
-                fn ($value, $locale) => $value !== null && $value !== '' && ($locales === null || in_array($locale, $locales ?? [])),
+                fn ($value, $locale) => $this->filterTranslations($value, $locale, $allowedLocales),
                 ARRAY_FILTER_USE_BOTH
             );
         }
 
-        return array_reduce($this->getTranslatableAttributes(), function ($result, $item) use ($locales) {
-            $result[$item] = $this->getTranslations($item, $locales);
+        return array_reduce($this->getTranslatableAttributes(), function ($result, $item) use ($allowedLocales) {
+            $result[$item] = $this->getTranslations($item, $allowedLocales);
 
             return $result;
         });
@@ -203,6 +203,27 @@ trait HasTranslations
         }
 
         return $locale;
+    }
+
+    protected function filterTranslations(string $value = null, string $locale = null, array $allowedLocales = null): bool
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        if ($value === '') {
+            return false;
+        }
+
+        if ($allowedLocales === null) {
+            return true;
+        }
+
+        if (! in_array($locale, $allowedLocales)) {
+            return false;
+        }
+
+        return true;
     }
 
     public function setLocale(string $locale): self

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -71,19 +71,20 @@ trait HasTranslations
         return $this->getTranslation($key, $locale, false);
     }
 
-    public function getTranslations(string $key = null): array
+    public function getTranslations(string $key = null, array $locales = null): array
     {
         if ($key !== null) {
             $this->guardAgainstNonTranslatableAttribute($key);
 
             return array_filter(
                 json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [],
-                fn ($value) => $value !== null && $value !== ''
+                fn ($value, $locale) => $value !== null && $value !== '' && ($locales === null || in_array($locale, $locales ?? [])),
+                ARRAY_FILTER_USE_BOTH
             );
         }
 
-        return array_reduce($this->getTranslatableAttributes(), function ($result, $item) {
-            $result[$item] = $this->getTranslations($item);
+        return array_reduce($this->getTranslatableAttributes(), function ($result, $item) use ($locales) {
+            $result[$item] = $this->getTranslations($item, $locales);
 
             return $result;
         });

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -141,6 +141,18 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_specified_translations_in_one_go()
+    {
+        $this->testModel->setTranslation('name', 'en', 'testValue_en');
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+        $this->testModel->save();
+
+        $this->assertSame([
+            'en' => 'testValue_en',
+        ], $this->testModel->getTranslations('name', ['en']));
+    }
+
+    /** @test */
     public function it_can_get_all_translations_for_all_translatable_attributes_in_one_go()
     {
         $this->testModel->setTranslation('name', 'en', 'testValue_en');
@@ -167,6 +179,26 @@ class TranslatableTest extends TestCase
                 'fr' => 'testValue_fr',
             ],
         ], $this->testModel->getTranslations());
+    }
+
+    /** @test */
+    public function it_can_get_specified_translations_for_all_translatable_attributes_in_one_go()
+    {
+        $this->testModel->setTranslation('name', 'en', 'testValue_en');
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+
+        $this->testModel->setTranslation('other_field', 'en', 'testValue_en');
+        $this->testModel->setTranslation('other_field', 'fr', 'testValue_fr');
+
+        $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
+        $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
+        $this->testModel->save();
+
+        $this->assertSame([
+            'name' => ['en' => 'testValue_en'],
+            'other_field' => ['en' => 'testValue_en'],
+            'field_with_mutator' => ['en' => 'testValue_en'],
+        ], $this->testModel->getTranslations(null, ['en']));
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds a new `$locales` argument to the `getTranslations` method to filter the translations.
Exmaple:
```php
$model->name = [
    'en' => 'Hello',
    'fr' => 'Bonjour',
    'de' => 'Hallo',
];

$model->getTranslations('name', ['en', 'fr']); // returns ['en' => 'Hello', 'fr' => 'Bonjour']
```

Also, the **tests** implemented for this feature and the `README` updated.