### PR TITLE
Solve the string value issue in filterTranslations method

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -205,7 +205,7 @@ trait HasTranslations
         return $locale;
     }
 
-    protected function filterTranslations(string $value = null, string $locale = null, array $allowedLocales = null): bool
+    protected function filterTranslations(mixed $value = null, string $locale = null, array $allowedLocales = null): bool
     {
         if ($value === null) {
             return false;


### PR DESCRIPTION
This PR resolves the mentioned issue in #299  by @killgt related to non-string translations value.