### PR TITLE
Add 'forgetTranslations' method

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -119,8 +119,12 @@ trait HasTranslations
     {
         $this->guardAgainstNonTranslatableAttribute($key);
 
-        foreach ($translations as $locale => $translation) {
-            $this->setTranslation($key, $locale, $translation);
+        if (! empty ($translations)) {
+            foreach ($translations as $locale => $translation) {
+                $this->setTranslation($key, $locale, $translation);
+            }
+        } else {
+            $this->attributes[$key] = $this->asJson([]);
         }
 
         return $this;
@@ -136,6 +140,21 @@ trait HasTranslations
         );
 
         $this->setTranslations($key, $translations);
+
+        return $this;
+    }
+
+    public function forgetTranslations(string $key, bool $asNull = false): self
+    {
+        $this->guardAgainstNonTranslatableAttribute($key);
+
+        collect($this->getTranslatedLocales($key))->each(function (string $locale) use ($key) {
+            $this->forgetTranslation($key, $locale);
+        });
+
+        if ($asNull) {
+            $this->attributes[$key] = null;
+        }
 
         return $this;
     }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -231,6 +231,52 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_forget_all_translations_of_field()
+    {
+        $this->testModel->setTranslation('name', 'en', 'testValue_en');
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+        $this->testModel->save();
+
+        $this->assertSame([
+            'en' => 'testValue_en',
+            'fr' => 'testValue_fr',
+        ], $this->testModel->getTranslations('name'));
+
+        $this->testModel->forgetTranslations('name');
+
+        $this->assertSame('[]', $this->testModel->getAttributes()['name']);
+        $this->assertSame([], $this->testModel->getTranslations('name'));
+
+        $this->testModel->save();
+
+        $this->assertSame('[]', $this->testModel->fresh()->getAttributes()['name']);
+        $this->assertSame([], $this->testModel->fresh()->getTranslations('name'));
+    }
+
+    /** @test */
+    public function it_can_forget_all_translations_of_field_and_make_field_null()
+    {
+        $this->testModel->setTranslation('name', 'en', 'testValue_en');
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+        $this->testModel->save();
+
+        $this->assertSame([
+            'en' => 'testValue_en',
+            'fr' => 'testValue_fr',
+        ], $this->testModel->getTranslations('name'));
+
+        $this->testModel->forgetTranslations('name', true);
+
+        $this->assertNull($this->testModel->getAttributes()['name']);
+        $this->assertSame([], $this->testModel->getTranslations('name'));
+
+        $this->testModel->save();
+
+        $this->assertNull($this->testModel->fresh()->getAttributes()['name']);
+        $this->assertSame([], $this->testModel->fresh()->getTranslations('name'));
+    }
+
+    /** @test */
     public function it_can_forget_a_field_with_mutator_translation()
     {
         $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');


### PR DESCRIPTION
Currently it is not possible to delete all translations of certain attribute while also having the option to save null instead of an empty json string (e.g. `{"en": null, "nl": null}`). This PR adds the `forgotTranslations` method to support this behavior.

The `forgotTranslations` method has 2 parameters:
- the attribute key
- a boolean that allows you to set the attribute to null after forgetting the translations of the attribute

```
$article->forgetTranslations('title'); // 'title' attribute is empty array
$article->forgetTranslations('title', true); // 'title' attribute is null
```

To add this method I had to make a very small change in the `setTranslations` method. If you call that method with an empty array, then the attribute will not be updated/set. To solve this I added an explicit check so the attribute can be set to an empty array.