### PR TITLE
Add alias feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,35 @@ trait HasTranslations
 }
 ```
 
+### Using aliases
+
+Sometimes clients of your app might use locale names that do not match
+the names you use on e.g. the web. An example might be having an iOS client
+and using the OS locale to get translated model attributes from your API.
+
+You can easily add aliases via the configuration:
+
+```php
+// config/translatable.php
+return [
+    // ...
+    'locales' => [
+        'de' => 'German',
+        'en' => 'English'
+    ],
+    
+    'aliases' => [
+        'de-DE' => 'de',
+        'en-US' => 'en',
+        'en-GB' => 'en'
+    ],
+];
+```
+
+After adding the aliases to your configuration when requesting a translation
+for the `de-DE` locale your app will properly return the translations for your
+internal `de` locale.
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -186,6 +186,8 @@ trait HasTranslations
 
     protected function normalizeLocale(string $key, string $locale, bool $useFallbackLocale): string
     {
+        $locale = config("translatable.aliases.$locale", $locale);
+
         if (in_array($locale, $this->getTranslatedLocales($key))) {
             return $locale;
         }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -608,4 +608,22 @@ class TranslatableTest extends TestCase
 
         $this->assertEquals($newTranslations, $this->testModel->getTranslations('name'));
     }
+
+    /** @test */
+    public function it_can_use_aliases()
+    {
+        $translations = ['de' => 'Welt', 'en' => 'World'];
+
+        $this->testModel->setTranslations('name', $translations);
+        $this->testModel->save();
+
+        $this->app['config']->set('translatable.fallback_locale', 'en');
+
+        // Will use the fallback locale
+        $this->assertEquals('World', $this->testModel->getTranslation('name', 'deutsch'));
+
+        $this->app['config']->set('translatable.aliases.deutsch', 'de');
+
+        $this->assertEquals('Welt', $this->testModel->getTranslation('name', 'deutsch'));
+    }
 }


### PR DESCRIPTION
This adds the possibility to define alias locales in case one wants to use the same translation for different locales like when another client sends locales in a different format.