### PR TITLE
fix: allow JSON fields to be translated

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -27,8 +27,18 @@ trait HasTranslations
 
     public function setAttribute($key, $value)
     {
-        if ($this->isTranslatableAttribute($key) && is_array($value)) {
-            return $this->setTranslations($key, $value);
+        if ($this->isTranslatableAttribute($key)) {
+            // Pragmatic approach to check if the passed value is a map of 
+            // translations or just any JSON object. The regular expression
+            // simply checks if all the keys look like locales.
+            // See: https://newbedev.com/regex-to-detect-locales
+            $isTranslationMap = is_array($value) && collect($value)->every(function ($value, $key) {
+              return preg_match('/^[A-Za-z]{2,4}([_-][A-Za-z]{4})?([_-]([A-Za-z]{2}|[0-9]{3}))?$/', $key);
+            });
+
+            if ($isTranslationMap) {
+              return $this->setTranslations($key, $value);
+            }
         }
 
         // Pass arrays and untranslatable attributes to the parent method.

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -28,12 +28,6 @@ trait HasTranslations
 
     public function setAttribute($key, $value)
     {
-        if ($this->isTranslatableAttribute($key)) {
-            if ($this->isTranslationMap($value)) {
-              return $this->setTranslations($key, $value);
-            }
-        }
-
         // Pass arrays and untranslatable attributes to the parent method.
         if (! $this->isTranslatableAttribute($key)) {
             return parent::setAttribute($key, $value);
@@ -263,17 +257,5 @@ trait HasTranslations
             parent::getCasts(),
             array_fill_keys($this->getTranslatableAttributes(), 'array')
         );
-    }
-
-    public function isTranslationMap(mixed $value): bool {
-        // Pragmatic approach to check if the passed value is a map of 
-        // translations or just any JSON object.
-        if (!is_array($value)) {
-            return false;
-        }
-
-        return collect($value)->every(function ($value, $key) {
-            return Locale::getDisplayName($key) !== $key;
-        });  
     }
 }

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -29,13 +29,7 @@ trait HasTranslations
     public function setAttribute($key, $value)
     {
         if ($this->isTranslatableAttribute($key)) {
-            // Pragmatic approach to check if the passed value is a map of 
-            // translations or just any JSON object.
-            $isTranslationMap = is_array($value) && collect($value)->every(function ($value, $key) {
-              return Locale::getDisplayName($key) !== $key;
-            });
-
-            if ($isTranslationMap) {
+            if ($this->isTranslationMap($value)) {
               return $this->setTranslations($key, $value);
             }
         }
@@ -269,5 +263,17 @@ trait HasTranslations
             parent::getCasts(),
             array_fill_keys($this->getTranslatableAttributes(), 'array')
         );
+    }
+
+    public function isTranslationMap(mixed $value): bool {
+        // Pragmatic approach to check if the passed value is a map of 
+        // translations or just any JSON object.
+        if (!is_array($value)) {
+            return false;
+        }
+
+        return collect($value)->every(function ($value, $key) {
+            return Locale::getDisplayName($key) !== $key;
+        });  
     }
 }

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Translatable;
 
+use Locale;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Spatie\Translatable\Events\TranslationHasBeenSet;
@@ -29,11 +30,9 @@ trait HasTranslations
     {
         if ($this->isTranslatableAttribute($key)) {
             // Pragmatic approach to check if the passed value is a map of 
-            // translations or just any JSON object. The regular expression
-            // simply checks if all the keys look like locales.
-            // See: https://newbedev.com/regex-to-detect-locales
+            // translations or just any JSON object.
             $isTranslationMap = is_array($value) && collect($value)->every(function ($value, $key) {
-              return preg_match('/^[A-Za-z]{2,4}([_-][A-Za-z]{4})?([_-]([A-Za-z]{2}|[0-9]{3}))?$/', $key);
+              return Locale::getDisplayName($key) !== $key;
             });
 
             if ($isTranslationMap) {
@@ -42,7 +41,7 @@ trait HasTranslations
         }
 
         // Pass arrays and untranslatable attributes to the parent method.
-        if (! $this->isTranslatableAttribute($key) || is_array($value)) {
+        if (! $this->isTranslatableAttribute($key)) {
             return parent::setAttribute($key, $value);
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,6 +28,7 @@ abstract class TestCase extends Orchestra
             $table->text('name')->nullable();
             $table->text('other_field')->nullable();
             $table->text('field_with_mutator')->nullable();
+            $table->json('json_field')->nullable();
         });
     }
 }

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -14,7 +14,7 @@ class TestModel extends Model
     protected $guarded = [];
     public $timestamps = false;
 
-    public $translatable = ['name', 'other_field', 'field_with_mutator'];
+    public $translatable = ['name', 'other_field', 'field_with_mutator', 'json_field'];
 
     public function setFieldWithMutatorAttribute($value)
     {

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -624,35 +624,35 @@ class TranslatableTest extends TestCase
     /** @test */
     public function it_can_translate_json_fields()
     {
-        $en = [ 'text' => 'hello' ];
-        $this->testModel->json_field = $en;
+        $englishTranslation = [ 'text' => 'hello' ];
+        $this->testModel->json_field = $englishTranslation;
         $this->testModel->save();
 
         $this->assertEquals($this->testModel->json_field, $this->testModel->getTranslations('json_field')['en']);
 
-        $de = [ 'text' => 'hallo' ];
+        $germanTranslation = [ 'text' => 'hallo' ];
         $this->testModel->setLocale('de');
-        $this->testModel->json_field = $de;
+        $this->testModel->json_field = $germanTranslation;
         $this->testModel->save();
 
-        $this->assertEquals([ 'en' => $en, 'de' => $de ], $this->testModel->getTranslations('json_field'));
+        $this->assertEquals([ 'en' => $englishTranslation, 'de' => $germanTranslation ], $this->testModel->getTranslations('json_field'));
 
         $translations = ['nl' => [ 'text' => 'hallo' ], 'kh' => [ 'text' => 'សួរស្តី' ]];
         $this->testModel->setTranslations('json_field', $translations);
         $this->testModel->save();
 
-        $this->assertEquals(array_merge($translations, [  'en' => $en, 'de' => $de ]), $this->testModel->getTranslations('json_field'));
+        $this->assertEquals(array_merge($translations, [  'en' => $englishTranslation, 'de' => $germanTranslation ]), $this->testModel->getTranslations('json_field'));
 
         $newTranslations = ['es' => [ 'text' => 'hola' ]];
         $this->testModel->replaceTranslations('json_field', $newTranslations);
 
         $this->assertEquals($newTranslations, $this->testModel->getTranslations('json_field'));
 
-        $fr = [ 'text' => 'bonjour' ];
-        $it = [ 'text' => 'ciao' ];
-        $this->testModel->json_field = [ 'fr-FR' => $fr, 'it_IT' => $it ];
+        $frenchTranslation = [ 'text' => 'bonjour' ];
+        $italianTranslation = [ 'text' => 'ciao' ];
+        $this->testModel->json_field = [ 'fr-FR' => $frenchTranslation, 'it_IT' => $italianTranslation ];
         $this->testModel->save();
 
-        $this->assertEquals(array_merge([ 'fr-FR' => $fr, 'it_IT' => $it ], $newTranslations), $this->testModel->getTranslations('json_field'));
+        $this->assertEquals(array_merge([ 'fr-FR' => $frenchTranslation, 'it_IT' => $italianTranslation ], $newTranslations), $this->testModel->getTranslations('json_field'));
     }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -98,7 +98,7 @@ class TranslatableTest extends TestCase
     public function it_can_set_translated_values_when_creating_a_model()
     {
         $model = TestModel::create([
-            'name' => ['en' => 'testValue_en'],
+            'name' => 'testValue_en',
         ]);
 
         $this->assertSame('testValue_en', $model->name);
@@ -358,11 +358,9 @@ class TranslatableTest extends TestCase
     public function it_can_set_translations_for_default_language()
     {
         $model = TestModel::create([
-            'name' => [
-                'en' => 'testValue_en',
-                'fr' => 'testValue_fr',
-            ],
+            'name' => 'testValue_en',
         ]);
+        $model->setTranslation('name', 'fr', 'testValue_fr');
 
         app()->setLocale('en');
 
@@ -450,21 +448,6 @@ class TranslatableTest extends TestCase
         ];
 
         $this->assertEquals($expected, $testModel->getTranslations('name'));
-    }
-
-    /** @test */
-    public function it_can_set_multiple_translations_on_field_when_a_mutator_is_defined()
-    {
-        $translations = [
-            'nl' => 'hallo',
-            'en' => 'hello',
-        ];
-
-        $testModel = $this->testModel;
-        $testModel->field_with_mutator = $translations;
-        $testModel->save();
-
-        $this->assertEquals($translations, $testModel->getTranslations('field_with_mutator'));
     }
 
     /** @test */
@@ -650,7 +633,8 @@ class TranslatableTest extends TestCase
 
         $frenchTranslation = [ 'text' => 'bonjour' ];
         $italianTranslation = [ 'text' => 'ciao' ];
-        $this->testModel->json_field = [ 'fr-FR' => $frenchTranslation, 'it_IT' => $italianTranslation ];
+        $this->testModel->setTranslation('json_field', 'fr-FR', $frenchTranslation);
+        $this->testModel->setTranslation('json_field', 'it_IT', $italianTranslation);
         $this->testModel->save();
 
         $this->assertEquals(array_merge([ 'fr-FR' => $frenchTranslation, 'it_IT' => $italianTranslation ], $newTranslations), $this->testModel->getTranslations('json_field'));

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -163,6 +163,9 @@ class TranslatableTest extends TestCase
 
         $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
         $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
+
+        $this->testModel->setTranslation('json_field', 'en', 'testValue_en');
+        $this->testModel->setTranslation('json_field', 'fr', 'testValue_fr');
         $this->testModel->save();
 
         $this->assertSame([
@@ -175,6 +178,10 @@ class TranslatableTest extends TestCase
                 'fr' => 'testValue_fr',
             ],
             'field_with_mutator' => [
+                'en' => 'testValue_en',
+                'fr' => 'testValue_fr',
+            ],
+            'json_field' => [
                 'en' => 'testValue_en',
                 'fr' => 'testValue_fr',
             ],
@@ -192,12 +199,16 @@ class TranslatableTest extends TestCase
 
         $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
         $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
+
+        $this->testModel->setTranslation('json_field', 'en', 'testValue_en');
+        $this->testModel->setTranslation('json_field', 'fr', 'testValue_fr');
         $this->testModel->save();
 
         $this->assertSame([
             'name' => ['en' => 'testValue_en'],
             'other_field' => ['en' => 'testValue_en'],
             'field_with_mutator' => ['en' => 'testValue_en'],
+            'json_field' => ['en' => 'testValue_en'],
         ], $this->testModel->getTranslations(null, ['en']));
     }
 
@@ -515,6 +526,7 @@ class TranslatableTest extends TestCase
             'name' => ['nl' => 'hallo', 'en' => 'hello'],
             'other_field' => [],
             'field_with_mutator' => ['nl' => 'hallo', 'en' => 'hello'],
+            'json_field' => [],
         ], $this->testModel->translations);
     }
 
@@ -607,5 +619,40 @@ class TranslatableTest extends TestCase
         $this->testModel->replaceTranslations('name', $newTranslations);
 
         $this->assertEquals($newTranslations, $this->testModel->getTranslations('name'));
+    }
+
+    /** @test */
+    public function it_can_translate_json_fields()
+    {
+        $en = [ 'text' => 'hello' ];
+        $this->testModel->json_field = $en;
+        $this->testModel->save();
+
+        $this->assertEquals($this->testModel->json_field, $this->testModel->getTranslations('json_field')['en']);
+
+        $de = [ 'text' => 'hallo' ];
+        $this->testModel->setLocale('de');
+        $this->testModel->json_field = $de;
+        $this->testModel->save();
+
+        $this->assertEquals([ 'en' => $en, 'de' => $de ], $this->testModel->getTranslations('json_field'));
+
+        $translations = ['nl' => [ 'text' => 'hallo' ], 'kh' => [ 'text' => 'សួរស្តី' ]];
+        $this->testModel->setTranslations('json_field', $translations);
+        $this->testModel->save();
+
+        $this->assertEquals(array_merge($translations, [  'en' => $en, 'de' => $de ]), $this->testModel->getTranslations('json_field'));
+
+        $newTranslations = ['es' => [ 'text' => 'hola' ]];
+        $this->testModel->replaceTranslations('json_field', $newTranslations);
+
+        $this->assertEquals($newTranslations, $this->testModel->getTranslations('json_field'));
+
+        $fr = [ 'text' => 'bonjour' ];
+        $it = [ 'text' => 'ciao' ];
+        $this->testModel->json_field = [ 'fr-FR' => $fr, 'it_IT' => $it ];
+        $this->testModel->save();
+
+        $this->assertEquals(array_merge([ 'fr-FR' => $fr, 'it_IT' => $it ], $newTranslations), $this->testModel->getTranslations('json_field'));
     }
 }


### PR DESCRIPTION
Currently, it is not possible to translate JSON fields because the `is_array` condition becomes true when you pass an array (i.e. a decoded JSON object). This PR adds a simple check that checks if the passed object is an array with locale keys only and if the condition is true it sets all translations at once.