### PR TITLE
Return any translation if neither preferred locale nor fallback locale found

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,12 @@ php artisan vendor:publish --provider="Spatie\Translatable\TranslatableServicePr
 This is the contents of the published file:
 ```php
 return [
-  'fallback_locale' => 'en',
+  'fallback_locale' => null,
+  'fallback_any' => false,
 ];
 ```
+
+Sometimes it is favored to return any translation if neigher the translation for the prefered locale nor the fallbacl locale are set. To do so, set fallback_any in the config to true.
 
 ## Making a model translatable
 

--- a/config/translatable.php
+++ b/config/translatable.php
@@ -6,4 +6,10 @@ return [
      * If a translation has not been set for a given locale, use this locale instead.
      */
     'fallback_locale' => null,
+
+    /*
+     * If a translation has not been set for a given locale and the fallback locale,
+     * any other locale will be chosen instead.
+     */
+    'fallback_any' => false,
 ];

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -186,7 +186,9 @@ trait HasTranslations
 
     protected function normalizeLocale(string $key, string $locale, bool $useFallbackLocale): string
     {
-        if (in_array($locale, $this->getTranslatedLocales($key))) {
+        $translatedLocales = $this->getTranslatedLocales($key);
+
+        if (in_array($locale, $translatedLocales)) {
             return $locale;
         }
 
@@ -194,12 +196,13 @@ trait HasTranslations
             return $locale;
         }
 
-        if (! is_null($fallbackLocale = config('translatable.fallback_locale'))) {
+        $fallbackLocale = config('translatable.fallback_locale') ?? config('app.fallback_locale');
+        if (! is_null($fallbackLocale) && in_array($fallbackLocale, $translatedLocales)) {
             return $fallbackLocale;
         }
 
-        if (! is_null($fallbackLocale = config('app.fallback_locale'))) {
-            return $fallbackLocale;
+        if (! empty($translatedLocales) && config('translatable.fallback_any')) {
+            return $translatedLocales[0];
         }
 
         return $locale;

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -608,4 +608,75 @@ class TranslatableTest extends TestCase
 
         $this->assertEquals($newTranslations, $this->testModel->getTranslations('name'));
     }
+
+    /** @test */
+    public function it_can_use_any_locale_if_given_locale_not_set()
+    {
+        config()->set('app.fallback_locale', 'en');
+        config()->set('translatable.fallback_any', true);
+
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+        $this->testModel->setTranslation('name', 'de', 'testValue_de');
+        $this->testModel->save();
+
+        $this->testModel->setLocale('it');
+        $this->assertSame('testValue_fr', $this->testModel->name);
+    }
+
+    /** @test */
+    public function it_will_return_set_translation_when_fallback_any_set()
+    {
+        config()->set('app.fallback_locale', 'en');
+        config()->set('translatable.fallback_any', true);
+
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+        $this->testModel->setTranslation('name', 'de', 'testValue_de');
+        $this->testModel->save();
+
+        $this->testModel->setLocale('de');
+        $this->assertSame('testValue_de', $this->testModel->name);
+    }
+
+    /** @test */
+    public function it_will_return_fallback_translation_when_fallback_any_set()
+    {
+        config()->set('app.fallback_locale', 'en');
+        config()->set('translatable.fallback_any', true);
+
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+        $this->testModel->setTranslation('name', 'en', 'testValue_en');
+        $this->testModel->save();
+
+        $this->testModel->setLocale('de');
+        $this->assertSame('testValue_en', $this->testModel->name);
+    }
+
+    /** @test */
+    public function it_provides_a_flog_to_not_return_any_translation_when_getting_an_unknown_locale()
+    {
+        config()->set('app.fallback_locale', 'en');
+        config()->set('translatable.fallback_any', true);
+
+        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+        $this->testModel->setTranslation('name', 'de', 'testValue_de');
+        $this->testModel->save();
+
+        $this->testModel->setLocale('it');
+        $this->assertSame('', $this->testModel->getTranslation('name', 'it', false));
+    }
+
+    /** @test */
+    public function it_will_return_default_fallback_locale_translation_when_getting_an_unknown_locale_with_fallback_any()
+    {
+        config()->set('app.fallback_locale', 'en');
+        config()->set('translatable.fallback_any', true);
+
+        $this->testModel->setTranslation('name', 'en', 'testValue_en');
+        $this->testModel->save();
+
+        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'fr'));
+    }
+
+
+
 }


### PR DESCRIPTION
Often models are not fully translated into every needed language. When a field is missing the translation for the preferred user locale and the fallback locale, no text is shown at all.  
This change proposes an option to return the first translation available in the above described condition to enhance user experience. 