### PR TITLE
Changing the way to populate setTranslation

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -103,7 +103,8 @@ trait HasTranslations
 
             $this->{$method}($value, $locale);
 
-            $value = $this->attributes[$key];
+            $translated = $this->getTranslations($key);
+            $value = $translated[$locale] ?? '';
         }
 
         $translations[$locale] = $value;


### PR DESCRIPTION
When model hasSetMutator, repopulating $value at setTranslation will not work with json encoded value, as it will treat the value as a string value.

force the value to be retrieved via getTranslations method again to force convert json string into valid arrays.