### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,4 +40,4 @@ jobs:
                     composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
             -   name: Execute tests
-                run: vendor/bin/phpunit
+                run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     },
     "scripts": {
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
-        "test": "vendor/bin/phpunit"
+        "test": "vendor/bin/pest"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^7.0",
-        "phpunit/phpunit": "^9.5"
+        "pestphp/pest": "^1.20"
     },
     "autoload": {
         "psr-4": {

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -1,28 +1,18 @@
 <?php
 
-namespace Spatie\Translatable\Test;
-
 use Illuminate\Support\Facades\Event;
 use Spatie\Translatable\Events\TranslationHasBeenSetEvent;
 
-class EventTest extends TestCase
-{
-    protected TestModel $testModel;
+uses(TestCase::class);
 
-    public function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    Event::fake();
 
-        Event::fake();
+    $this->testModel = new TestModel();
+});
 
-        $this->testModel = new TestModel();
-    }
+it('will fire an event when a translation has been set', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
 
-    /** @test */
-    public function it_will_fire_an_event_when_a_translation_has_been_set()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-
-        Event::assertDispatched(TranslationHasBeenSetEvent::class);
-    }
-}
+    Event::assertDispatched(TranslationHasBeenSetEvent::class);
+});

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -2,8 +2,7 @@
 
 use Illuminate\Support\Facades\Event;
 use Spatie\Translatable\Events\TranslationHasBeenSetEvent;
-
-uses(TestCase::class);
+use Spatie\Translatable\Test\TestSupport\TestModel;
 
 beforeEach(function () {
     Event::fake();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+/** @link https://pestphp.com/docs/underlying-test-case */
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/** @link https://pestphp.com/docs/expectations#custom-expectations */
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/** @link https://pestphp.com/docs/helpers */

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+uses(\Spatie\Translatable\Test\TestCase::class)->in('tests');
+
 /*
 |--------------------------------------------------------------------------
 | Test Case

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,42 +1,6 @@
 <?php
 
-uses(\Spatie\Translatable\Test\TestCase::class)->in('tests');
+use Spatie\Translatable\Test\TestCase;
 
-/*
-|--------------------------------------------------------------------------
-| Test Case
-|--------------------------------------------------------------------------
-|
-| The closure you provide to your test functions is always bound to a specific PHPUnit test
-| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
-| need to change it using the "uses()" function to bind a different classes or traits.
-|
-*/
+uses(TestCase::class)->in(__DIR__);
 
-/** @link https://pestphp.com/docs/underlying-test-case */
-
-/*
-|--------------------------------------------------------------------------
-| Expectations
-|--------------------------------------------------------------------------
-|
-| When you're writing tests, you often need to check that values meet certain conditions. The
-| "expect()" function gives you access to a set of "expectations" methods that you can use
-| to assert different things. Of course, you may extend the Expectation API at any time.
-|
-*/
-
-/** @link https://pestphp.com/docs/expectations#custom-expectations */
-
-/*
-|--------------------------------------------------------------------------
-| Functions
-|--------------------------------------------------------------------------
-|
-| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
-| project that you don't want to repeat in every file. Here you can also expose helpers as
-| global functions to help you to reduce the number of lines of code in your test files.
-|
-*/
-
-/** @link https://pestphp.com/docs/helpers */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,7 @@ use Spatie\Translatable\TranslatableServiceProvider;
 
 abstract class TestCase extends Orchestra
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestSupport/TestModel.php
+++ b/tests/TestSupport/TestModel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Translatable\Test;
+namespace Spatie\Translatable\Test\TestSupport;
 
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Translatable\HasTranslations;

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -1,824 +1,709 @@
 <?php
 
-namespace Spatie\Translatable\Test;
-
 use Illuminate\Support\Facades\Storage;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 use Spatie\Translatable\Facades\Translatable;
 
-class TranslatableTest extends TestCase
-{
-    protected TestModel $testModel;
+uses(TestCase::class);
 
-    public function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    $this->testModel = new TestModel();
+});
 
-        $this->testModel = new TestModel();
-    }
+it('will return package fallback locale translation when getting an unknown locale', function () {
+    config()->set('app.fallback_locale', 'nl');
+    Translatable::fallback(
+        fallbackLocale: 'en',
+    );
 
-    /** @test */
-    public function it_will_return_package_fallback_locale_translation_when_getting_an_unknown_locale()
-    {
-        config()->set('app.fallback_locale', 'nl');
-        Translatable::fallback(
-            fallbackLocale: 'en',
-        );
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'fr'));
+});
 
-        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'fr'));
-    }
+it('will return default fallback locale translation when getting an unknown locale', function () {
+    config()->set('app.fallback_locale', 'en');
 
-    /** @test */
-    public function it_will_return_default_fallback_locale_translation_when_getting_an_unknown_locale()
-    {
-        config()->set('app.fallback_locale', 'en');
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'fr'));
+});
 
-        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'fr'));
-    }
+it('provides a flog to not return fallback locale translation when getting an unknown locale', function () {
+    config()->set('app.fallback_locale', 'en');
 
-    /** @test */
-    public function it_provides_a_flog_to_not_return_fallback_locale_translation_when_getting_an_unknown_locale()
-    {
-        config()->set('app.fallback_locale', 'en');
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('', $this->testModel->getTranslation('name', 'fr', false));
+});
 
-        $this->assertSame('', $this->testModel->getTranslation('name', 'fr', false));
-    }
+it('will return fallback locale translation when getting an unknown locale and fallback is true', function () {
+    config()->set('app.fallback_locale', 'en');
 
-    /** @test */
-    public function it_will_return_fallback_locale_translation_when_getting_an_unknown_locale_and_fallback_is_true()
-    {
-        config()->set('app.fallback_locale', 'en');
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
+});
 
-        $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
-    }
+it('will execute callback fallback when getting an unknown locale and fallback callback is enabled', function () {
+    Storage::fake();
 
-    /** @test */
-    public function it_will_execute_callback_fallback_when_getting_an_unknown_locale_and_fallback_callback_is_enabled()
-    {
-        Storage::fake();
+    Translatable::fallback(missingKeyCallback: function ($model, string $translationKey, string $locale) {
+        //something assertable outside the closure
+        Storage::put("test.txt", "test");
+    });
 
-        Translatable::fallback(missingKeyCallback: function ($model, string $translationKey, string $locale) {
-            //something assertable outside the closure
-            Storage::put("test.txt", "test");
-        });
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
 
-        $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
+    Storage::assertExists("test.txt");
+});
 
-        Storage::assertExists("test.txt");
-    }
+it('will use callback fallback return value as translation', function () {
+    Translatable::fallback(missingKeyCallback: function ($model, string $translationKey, string $locale) {
+        return "testValue_fallback_callback";
+    });
 
-    /** @test */
-    public function it_will_use_callback_fallback_return_value_as_translation()
-    {
-        Translatable::fallback(missingKeyCallback: function ($model, string $translationKey, string $locale) {
-            return "testValue_fallback_callback";
-        });
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('testValue_fallback_callback', $this->testModel->getTranslationWithFallback('name', 'fr'));
+});
 
-        $this->assertSame('testValue_fallback_callback', $this->testModel->getTranslationWithFallback('name', 'fr'));
-    }
+it('wont use callback fallback return value as translation if it is not a string', function () {
+    Translatable::fallback(missingKeyCallback: function ($model, string $translationKey, string $locale) {
+        return 123456;
+    });
 
-    /** @test */
-    public function it_wont_use_callback_fallback_return_value_as_translation_if_it_is_not_a_string()
-    {
-        Translatable::fallback(missingKeyCallback: function ($model, string $translationKey, string $locale) {
-            return 123456;
-        });
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
+});
 
-        $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
-    }
+it('wont execute callback fallback when getting an existing translation', function () {
+    Storage::fake();
 
-    /** @test */
-    public function it_wont_execute_callback_fallback_when_getting_an_existing_translation()
-    {
-        Storage::fake();
+    Translatable::fallback(missingKeyCallback: function ($model, string $translationKey, string $locale) {
+        //something assertable outside the closure
+        Storage::put("test.txt", "test");
+    });
 
-        Translatable::fallback(missingKeyCallback: function ($model, string $translationKey, string $locale) {
-            //something assertable outside the closure
-            Storage::put("test.txt", "test");
-        });
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'en'));
 
-        $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'en'));
+    Storage::assertMissing("test.txt");
+});
 
-        Storage::assertMissing("test.txt");
-    }
+it('wont fail if callback fallback throw exception', function () {
+    Translatable::fallback(missingKeyCallback: function ($model, string $translationKey, string $locale) {
+        throw new \Exception();
+    });
 
-    /** @test */
-    public function it_wont_fail_if_callback_fallback_throw_exception()
-    {
-        Translatable::fallback(missingKeyCallback: function ($model, string $translationKey, string $locale) {
-            throw new \Exception();
-        });
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
+});
 
-        $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
-    }
+it('will return an empty string when getting an unknown locale and fallback is not set', function () {
+    config()->set('app.fallback_locale', '');
 
-    /** @test */
-    public function it_will_return_an_empty_string_when_getting_an_unknown_locale_and_fallback_is_not_set()
-    {
-        config()->set('app.fallback_locale', '');
+    Translatable::fallback(
+        fallbackLocale: '',
+    );
 
-        Translatable::fallback(
-            fallbackLocale: '',
-        );
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('', $this->testModel->getTranslationWithoutFallback('name', 'fr'));
+});
 
-        $this->assertSame('', $this->testModel->getTranslationWithoutFallback('name', 'fr'));
-    }
+it('will return an empty string when getting an unknown locale and fallback is empty', function () {
+    config()->set('app.fallback_locale', '');
 
-    /** @test */
-    public function it_will_return_an_empty_string_when_getting_an_unknown_locale_and_fallback_is_empty()
-    {
-        config()->set('app.fallback_locale', '');
+    Translatable::fallback(
+        fallbackLocale: '',
+    );
 
-        Translatable::fallback(
-            fallbackLocale: '',
-        );
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('', $this->testModel->getTranslation('name', 'fr'));
+});
 
-        $this->assertSame('', $this->testModel->getTranslation('name', 'fr'));
-    }
+it('can save a translated attribute', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
 
-    /** @test */
-    public function it_can_save_a_translated_attribute()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
+    $this->assertSame('testValue_en', $this->testModel->name);
+});
 
-        $this->assertSame('testValue_en', $this->testModel->name);
-    }
+it('can set translated values when creating a model', function () {
+    $model = TestModel::create([
+        'name' => ['en' => 'testValue_en'],
+    ]);
 
-    /** @test */
-    public function it_can_set_translated_values_when_creating_a_model()
-    {
-        $model = TestModel::create([
-            'name' => ['en' => 'testValue_en'],
-        ]);
+    $this->assertSame('testValue_en', $model->name);
+});
 
-        $this->assertSame('testValue_en', $model->name);
-    }
+it('can save multiple translations', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->save();
 
-    /** @test */
-    public function it_can_save_multiple_translations()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->save();
+    $this->assertSame('testValue_en', $this->testModel->name);
+    $this->assertSame('testValue_fr', $this->testModel->getTranslation('name', 'fr'));
+});
 
-        $this->assertSame('testValue_en', $this->testModel->name);
-        $this->assertSame('testValue_fr', $this->testModel->getTranslation('name', 'fr'));
-    }
+it('will return the value of the current locale when using the property', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->save();
 
-    /** @test */
-    public function it_will_return_the_value_of_the_current_locale_when_using_the_property()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue');
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->save();
+    app()->setLocale('fr');
 
-        app()->setLocale('fr');
+    $this->assertSame('testValue_fr', $this->testModel->name);
+});
 
-        $this->assertSame('testValue_fr', $this->testModel->name);
-    }
+it('can get all translations in one go', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->save();
 
-    /** @test */
-    public function it_can_get_all_translations_in_one_go()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->save();
+    $this->assertSame([
+        'en' => 'testValue_en',
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('name'));
+});
 
-        $this->assertSame([
+it('can get specified translations in one go', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->save();
+
+    $this->assertSame([
+        'en' => 'testValue_en',
+    ], $this->testModel->getTranslations('name', ['en']));
+});
+
+it('can get all translations for all translatable attributes in one go', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+
+    $this->testModel->setTranslation('other_field', 'en', 'testValue_en');
+    $this->testModel->setTranslation('other_field', 'fr', 'testValue_fr');
+
+    $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
+    $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
+    $this->testModel->save();
+
+    $this->assertSame([
+        'name' => [
             'en' => 'testValue_en',
             'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('name'));
-    }
-
-    /** @test */
-    public function it_can_get_specified_translations_in_one_go()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->save();
-
-        $this->assertSame([
-            'en' => 'testValue_en',
-        ], $this->testModel->getTranslations('name', ['en']));
-    }
-
-    /** @test */
-    public function it_can_get_all_translations_for_all_translatable_attributes_in_one_go()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-
-        $this->testModel->setTranslation('other_field', 'en', 'testValue_en');
-        $this->testModel->setTranslation('other_field', 'fr', 'testValue_fr');
-
-        $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
-        $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
-        $this->testModel->save();
-
-        $this->assertSame([
-            'name' => [
-                'en' => 'testValue_en',
-                'fr' => 'testValue_fr',
-            ],
-            'other_field' => [
-                'en' => 'testValue_en',
-                'fr' => 'testValue_fr',
-            ],
-            'field_with_mutator' => [
-                'en' => 'testValue_en',
-                'fr' => 'testValue_fr',
-            ],
-        ], $this->testModel->getTranslations());
-    }
-
-    /** @test */
-    public function it_can_get_specified_translations_for_all_translatable_attributes_in_one_go()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-
-        $this->testModel->setTranslation('other_field', 'en', 'testValue_en');
-        $this->testModel->setTranslation('other_field', 'fr', 'testValue_fr');
-
-        $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
-        $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
-        $this->testModel->save();
-
-        $this->assertSame([
-            'name' => ['en' => 'testValue_en'],
-            'other_field' => ['en' => 'testValue_en'],
-            'field_with_mutator' => ['en' => 'testValue_en'],
-        ], $this->testModel->getTranslations(null, ['en']));
-    }
-
-    /** @test */
-    public function it_can_get_the_locales_which_have_a_translation()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->save();
-
-        $this->assertSame(['en', 'fr'], $this->testModel->getTranslatedLocales('name'));
-    }
-
-    /** @test */
-    public function it_can_forget_a_translation()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->save();
-
-        $this->assertSame([
+        ],
+        'other_field' => [
             'en' => 'testValue_en',
             'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('name'));
-
-        $this->testModel->forgetTranslation('name', 'en');
-
-        $this->assertSame([
-            'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('name'));
-    }
-
-    /** @test */
-    public function it_can_forget_all_translations_of_field()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->save();
-
-        $this->assertSame([
+        ],
+        'field_with_mutator' => [
             'en' => 'testValue_en',
             'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('name'));
+        ],
+    ], $this->testModel->getTranslations());
+});
 
-        $this->testModel->forgetTranslations('name');
+it('can get specified translations for all translatable attributes in one go', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
 
-        $this->assertSame('[]', $this->testModel->getAttributes()['name']);
-        $this->assertSame([], $this->testModel->getTranslations('name'));
+    $this->testModel->setTranslation('other_field', 'en', 'testValue_en');
+    $this->testModel->setTranslation('other_field', 'fr', 'testValue_fr');
 
-        $this->testModel->save();
+    $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
+    $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
+    $this->testModel->save();
 
-        $this->assertSame('[]', $this->testModel->fresh()->getAttributes()['name']);
-        $this->assertSame([], $this->testModel->fresh()->getTranslations('name'));
-    }
+    $this->assertSame([
+        'name' => ['en' => 'testValue_en'],
+        'other_field' => ['en' => 'testValue_en'],
+        'field_with_mutator' => ['en' => 'testValue_en'],
+    ], $this->testModel->getTranslations(null, ['en']));
+});
 
-    /** @test */
-    public function it_can_forget_all_translations_of_field_and_make_field_null()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->save();
+it('can get the locales which have a translation', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->save();
 
-        $this->assertSame([
+    $this->assertSame(['en', 'fr'], $this->testModel->getTranslatedLocales('name'));
+});
+
+it('can forget a translation', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->save();
+
+    $this->assertSame([
+        'en' => 'testValue_en',
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('name'));
+
+    $this->testModel->forgetTranslation('name', 'en');
+
+    $this->assertSame([
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('name'));
+});
+
+it('can forget all translations of field', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->save();
+
+    $this->assertSame([
+        'en' => 'testValue_en',
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('name'));
+
+    $this->testModel->forgetTranslations('name');
+
+    $this->assertSame('[]', $this->testModel->getAttributes()['name']);
+    $this->assertSame([], $this->testModel->getTranslations('name'));
+
+    $this->testModel->save();
+
+    $this->assertSame('[]', $this->testModel->fresh()->getAttributes()['name']);
+    $this->assertSame([], $this->testModel->fresh()->getTranslations('name'));
+});
+
+it('can forget all translations of field and make field null', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->save();
+
+    $this->assertSame([
+        'en' => 'testValue_en',
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('name'));
+
+    $this->testModel->forgetTranslations('name', true);
+
+    $this->assertNull($this->testModel->getAttributes()['name']);
+    $this->assertSame([], $this->testModel->getTranslations('name'));
+
+    $this->testModel->save();
+
+    $this->assertNull($this->testModel->fresh()->getAttributes()['name']);
+    $this->assertSame([], $this->testModel->fresh()->getTranslations('name'));
+});
+
+it('can forget a field with mutator translation', function () {
+    $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
+    $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
+    $this->testModel->save();
+
+    $this->assertSame([
+        'en' => 'testValue_en',
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('field_with_mutator'));
+
+    $this->testModel->forgetTranslation('field_with_mutator', 'en');
+
+    $this->assertSame([
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('field_with_mutator'));
+});
+
+it('can forget all translations', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+
+    $this->testModel->setTranslation('other_field', 'en', 'testValue_en');
+    $this->testModel->setTranslation('other_field', 'fr', 'testValue_fr');
+
+    $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
+    $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
+    $this->testModel->save();
+
+    $this->assertSame([
+        'en' => 'testValue_en',
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('name'));
+
+    $this->assertSame([
+        'en' => 'testValue_en',
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('other_field'));
+
+    $this->assertSame([
+        'en' => 'testValue_en',
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('field_with_mutator'));
+
+    $this->testModel->forgetAllTranslations('en');
+
+    $this->assertSame([
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('name'));
+
+    $this->assertSame([
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('other_field'));
+
+    $this->assertSame([
+        'fr' => 'testValue_fr',
+    ], $this->testModel->getTranslations('field_with_mutator'));
+});
+
+it('will throw an exception when trying to translate an untranslatable attribute', function () {
+    $this->expectException(AttributeIsNotTranslatable::class);
+
+    $this->testModel->setTranslation('untranslated', 'en', 'value');
+});
+
+it('is compatible with accessors on non translatable attributes', function () {
+    $testModel = new class () extends TestModel {
+        public function getOtherFieldAttribute(): string
+        {
+            return 'accessorName';
+        }
+    };
+
+    $this->assertEquals((new $testModel())->otherField, 'accessorName');
+});
+
+it('can use accessors on translated attributes', function () {
+    $testModel = new class () extends TestModel {
+        public function getNameAttribute($value): string
+        {
+            return "I just accessed {$value}";
+        }
+    };
+
+    $testModel->setTranslation('name', 'en', 'testValue_en');
+
+    $this->assertEquals($testModel->name, 'I just accessed testValue_en');
+});
+
+it('can use mutators on translated attributes', function () {
+    $testModel = new class () extends TestModel {
+        public function setNameAttribute($value) {
+            $this->attributes['name'] = "I just mutated {$value}";
+        }
+    };
+
+    $testModel->setTranslation('name', 'en', 'testValue_en');
+
+    $this->assertEquals($testModel->name, 'I just mutated testValue_en');
+});
+
+it('can set translations for default language', function () {
+    $model = TestModel::create([
+        'name' => [
             'en' => 'testValue_en',
             'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('name'));
-
-        $this->testModel->forgetTranslations('name', true);
-
-        $this->assertNull($this->testModel->getAttributes()['name']);
-        $this->assertSame([], $this->testModel->getTranslations('name'));
-
-        $this->testModel->save();
-
-        $this->assertNull($this->testModel->fresh()->getAttributes()['name']);
-        $this->assertSame([], $this->testModel->fresh()->getTranslations('name'));
-    }
-
-    /** @test */
-    public function it_can_forget_a_field_with_mutator_translation()
-    {
-        $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
-        $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
-        $this->testModel->save();
-
-        $this->assertSame([
-            'en' => 'testValue_en',
-            'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('field_with_mutator'));
-
-        $this->testModel->forgetTranslation('field_with_mutator', 'en');
-
-        $this->assertSame([
-            'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('field_with_mutator'));
-    }
-
-    /** @test */
-    public function it_can_forget_all_translations()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-
-        $this->testModel->setTranslation('other_field', 'en', 'testValue_en');
-        $this->testModel->setTranslation('other_field', 'fr', 'testValue_fr');
-
-        $this->testModel->setTranslation('field_with_mutator', 'en', 'testValue_en');
-        $this->testModel->setTranslation('field_with_mutator', 'fr', 'testValue_fr');
-        $this->testModel->save();
-
-        $this->assertSame([
-            'en' => 'testValue_en',
-            'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('name'));
-
-        $this->assertSame([
-            'en' => 'testValue_en',
-            'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('other_field'));
-
-        $this->assertSame([
-            'en' => 'testValue_en',
-            'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('field_with_mutator'));
-
-        $this->testModel->forgetAllTranslations('en');
-
-        $this->assertSame([
-            'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('name'));
-
-        $this->assertSame([
-            'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('other_field'));
-
-        $this->assertSame([
-            'fr' => 'testValue_fr',
-        ], $this->testModel->getTranslations('field_with_mutator'));
-    }
-
-    /** @test */
-    public function it_will_throw_an_exception_when_trying_to_translate_an_untranslatable_attribute()
-    {
-        $this->expectException(AttributeIsNotTranslatable::class);
-
-        $this->testModel->setTranslation('untranslated', 'en', 'value');
-    }
-
-    /** @test */
-    public function it_is_compatible_with_accessors_on_non_translatable_attributes()
-    {
-        $testModel = new class () extends TestModel {
-            public function getOtherFieldAttribute(): string
-            {
-                return 'accessorName';
-            }
-        };
-
-        $this->assertEquals((new $testModel())->otherField, 'accessorName');
-    }
-
-    /** @test */
-    public function it_can_use_accessors_on_translated_attributes()
-    {
-        $testModel = new class () extends TestModel {
-            public function getNameAttribute($value): string
-            {
-                return "I just accessed {$value}";
-            }
-        };
-
-        $testModel->setTranslation('name', 'en', 'testValue_en');
-
-        $this->assertEquals($testModel->name, 'I just accessed testValue_en');
-    }
-
-    /** @test */
-    public function it_can_use_mutators_on_translated_attributes()
-    {
-        $testModel = new class () extends TestModel {
-            public function setNameAttribute($value)
-            {
-                $this->attributes['name'] = "I just mutated {$value}";
-            }
-        };
-
-        $testModel->setTranslation('name', 'en', 'testValue_en');
-
-        $this->assertEquals($testModel->name, 'I just mutated testValue_en');
-    }
-
-    /** @test */
-    public function it_can_set_translations_for_default_language()
-    {
-        $model = TestModel::create([
-            'name' => [
-                'en' => 'testValue_en',
-                'fr' => 'testValue_fr',
-            ],
-        ]);
-
-        app()->setLocale('en');
-
-        $model->name = 'updated_en';
-        $this->assertEquals('updated_en', $model->name);
-        $this->assertEquals('testValue_fr', $model->getTranslation('name', 'fr'));
-
-        app()->setLocale('fr');
-        $model->name = 'updated_fr';
-        $this->assertEquals('updated_fr', $model->name);
-        $this->assertEquals('updated_en', $model->getTranslation('name', 'en'));
-    }
-
-    /** @test */
-    public function it_can_set_multiple_translations_at_once()
-    {
-        $translations = ['nl' => 'hallo', 'en' => 'hello', 'kh' => 'សួរស្តី'];
-
-        $this->testModel->setTranslations('name', $translations);
-        $this->testModel->save();
-
-        $this->assertEquals($translations, $this->testModel->getTranslations('name'));
-    }
-
-    /** @test */
-    public function it_can_check_if_an_attribute_is_translatable()
-    {
-        $this->assertTrue($this->testModel->isTranslatableAttribute('name'));
-
-        $this->assertFalse($this->testModel->isTranslatableAttribute('other'));
-    }
-
-    /** @test */
-    public function it_can_check_if_an_attribute_has_translation()
-    {
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'nl', null);
-        $this->testModel->save();
-
-        $this->assertTrue($this->testModel->hasTranslation('name', 'en'));
-
-        $this->assertFalse($this->testModel->hasTranslation('name', 'pt'));
-    }
-
-    /** @test */
-    public function it_can_correctly_set_a_field_when_a_mutator_is_defined()
-    {
-        $testModel = (new class () extends TestModel {
-            public function setNameAttribute($value)
-            {
-                $this->attributes['name'] = "I just mutated {$value}";
-            }
-        });
-
-        $testModel->name = 'hello';
-
-        $expected = ['en' => 'I just mutated hello'];
-        $this->assertEquals($expected, $testModel->getTranslations('name'));
-    }
-
-    /** @test */
-    public function it_can_set_multiple_translations_when_a_mutator_is_defined()
-    {
-        $testModel = (new class () extends TestModel {
-            public function setNameAttribute($value)
-            {
-                $this->attributes['name'] = "I just mutated {$value}";
-            }
-        });
-
-        $translations = [
-            'nl' => 'hallo',
-            'en' => 'hello',
-            'kh' => 'សួរស្តី',
-        ];
-
-        $testModel->setTranslations('name', $translations);
-
-        $testModel->save();
-
-        $expected = [
-            'nl' => 'I just mutated hallo',
-            'en' => 'I just mutated hello',
-            'kh' => 'I just mutated សួរស្តី',
-        ];
-
-        $this->assertEquals($expected, $testModel->getTranslations('name'));
-    }
-
-    /** @test */
-    public function it_can_set_multiple_translations_on_field_when_a_mutator_is_defined()
-    {
-        $translations = [
-            'nl' => 'hallo',
-            'en' => 'hello',
-        ];
-
-        $testModel = $this->testModel;
-        $testModel->field_with_mutator = $translations;
-        $testModel->save();
-
-        $this->assertEquals($translations, $testModel->getTranslations('field_with_mutator'));
-    }
-
-    /** @test */
-    public function it_can_translate_a_field_based_on_the_translations_of_another_one()
-    {
-        $testModel = (new class () extends TestModel {
-            public function setOtherFieldAttribute($value, $locale = 'en')
-            {
-                $this->attributes['other_field'] = $value.' '.$this->getTranslation('name', $locale);
-            }
-        });
-
-        $testModel->setTranslations('name', [
-            'nl' => 'wereld',
-            'en' => 'world',
-        ]);
-
-        $testModel->setTranslations('other_field', [
-            'nl' => 'hallo',
-            'en' => 'hello',
-        ]);
-
-        $testModel->save();
-
-        $expected = [
-            'nl' => 'hallo wereld',
-            'en' => 'hello world',
-        ];
-
-        $this->assertEquals($expected, $testModel->getTranslations('other_field'));
-    }
-
-    /** @test */
-    public function it_handle_null_value_from_database()
-    {
-        $testModel = (new class () extends TestModel {
-            public function setAttributesExternally(array $attributes)
-            {
-                $this->attributes = $attributes;
-            }
-        });
-
-        $testModel->setAttributesExternally(['name' => json_encode(null), 'other_field' => null]);
-
-        $this->assertEquals('', $testModel->name);
-        $this->assertEquals('', $testModel->other_field);
-    }
-
-    /** @test */
-    public function it_can_get_all_translations()
-    {
-        $translations = ['nl' => 'hallo', 'en' => 'hello'];
-
-        $this->testModel->setTranslations('name', $translations);
-        $this->testModel->setTranslations('field_with_mutator', $translations);
-        $this->testModel->save();
-
-        $this->assertEquals([
-            'name' => ['nl' => 'hallo', 'en' => 'hello'],
-            'other_field' => [],
-            'field_with_mutator' => ['nl' => 'hallo', 'en' => 'hello'],
-        ], $this->testModel->translations);
-    }
-
-    /** @test */
-    public function it_will_return_fallback_locale_translation_when_getting_an_empty_translation_from_the_locale()
-    {
-        config()->set('app.fallback_locale', 'en');
-
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->setTranslation('name', 'nl', null);
-        $this->testModel->save();
-
-        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'nl'));
-    }
-
-    /** @test */
-    public function it_will_return_correct_translation_value_if_value_is_set_to_zero()
-    {
-        $this->testModel->setTranslation('name', 'nl', '0');
-        $this->testModel->save();
-
-        $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
-    }
-
-    /** @test */
-    public function it_will_not_return_fallback_value_if_value_is_set_to_zero()
-    {
-        config()->set('app.fallback_locale', 'en');
-
-        $this->testModel->setTranslation('name', 'en', '1');
-        $this->testModel->setTranslation('name', 'nl', '0');
-        $this->testModel->save();
-
-        $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
-    }
-
-    /** @test */
-    public function it_will_not_remove_zero_value_of_other_locale_in_database()
-    {
-        config()->set('app.fallback_locale', 'en');
-
-        $this->testModel->setTranslation('name', 'nl', '0');
-        $this->testModel->setTranslation('name', 'en', '1');
-        $this->testModel->save();
-
-        $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
-    }
-
-    /** @test */
-    public function it_can_be_translated_based_on_given_locale()
-    {
-        $value = 'World';
-
-        $this->testModel = TestModel::usingLocale('en')->fill([
-            'name' => $value,
-        ]);
-        $this->testModel->save();
-
-        $this->assertSame($value, $this->testModel->getTranslation('name', 'en'));
-    }
-
-    /** @test */
-    public function it_can_set_and_fetch_attributes_based_on_set_locale()
-    {
-        $en = 'World';
-        $fr = 'Monde';
-
-        $this->testModel->setLocale('en');
-        $this->testModel->name = $en;
-        $this->testModel->setLocale('fr');
-        $this->testModel->name = $fr;
-
-        $this->testModel->save();
-
-        $this->testModel->setLocale('en');
-        $this->assertSame($en, $this->testModel->name);
-        $this->testModel->setLocale('fr');
-        $this->assertSame($fr, $this->testModel->name);
-    }
-
-    /** @test */
-    public function it_can_replace_translations()
-    {
-        $translations = ['nl' => 'hallo', 'en' => 'hello', 'kh' => 'សួរស្តី'];
-
-        $this->testModel->setTranslations('name', $translations);
-        $this->testModel->save();
-
-        $newTranslations = ['es' => 'hola'];
-        $this->testModel->replaceTranslations('name', $newTranslations);
-
-        $this->assertEquals($newTranslations, $this->testModel->getTranslations('name'));
-    }
-
-    /** @test */
-    public function it_can_use_any_locale_if_given_locale_not_set()
-    {
-        config()->set('app.fallback_locale', 'en');
-
-        Translatable::fallback(
-            fallbackAny: true,
-        );
-
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->setTranslation('name', 'de', 'testValue_de');
-        $this->testModel->save();
-
-        $this->testModel->setLocale('it');
-        $this->assertSame('testValue_fr', $this->testModel->name);
-    }
-
-    /** @test */
-    public function it_will_return_set_translation_when_fallback_any_set()
-    {
-        config()->set('app.fallback_locale', 'en');
-
-        Translatable::fallback(
-            fallbackAny: true,
-        );
-
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->setTranslation('name', 'de', 'testValue_de');
-        $this->testModel->save();
-
-        $this->testModel->setLocale('de');
-        $this->assertSame('testValue_de', $this->testModel->name);
-    }
-
-    /** @test */
-    public function it_will_return_fallback_translation_when_fallback_any_set()
-    {
-        config()->set('app.fallback_locale', 'en');
-
-        Translatable::fallback(
-            fallbackAny: true,
-        );
-
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
-
-        $this->testModel->setLocale('de');
-        $this->assertSame('testValue_en', $this->testModel->name);
-    }
-
-    /** @test */
-    public function it_provides_a_flog_to_not_return_any_translation_when_getting_an_unknown_locale()
-    {
-        config()->set('app.fallback_locale', 'en');
-
-        Translatable::fallback(
-            fallbackAny: true,
-        );
-
-        $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
-        $this->testModel->setTranslation('name', 'de', 'testValue_de');
-        $this->testModel->save();
-
-        $this->testModel->setLocale('it');
-        $this->assertSame('', $this->testModel->getTranslation('name', 'it', false));
-    }
-
-    /** @test */
-    public function it_will_return_default_fallback_locale_translation_when_getting_an_unknown_locale_with_fallback_any()
-    {
-        config()->set('app.fallback_locale', 'en');
-
-        Translatable::fallback(
-            fallbackAny: true,
-        );
-
-        $this->testModel->setTranslation('name', 'en', 'testValue_en');
-        $this->testModel->save();
-
-        $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'fr'));
-    }
-}
+        ],
+    ]);
+
+    app()->setLocale('en');
+
+    $model->name = 'updated_en';
+    $this->assertEquals('updated_en', $model->name);
+    $this->assertEquals('testValue_fr', $model->getTranslation('name', 'fr'));
+
+    app()->setLocale('fr');
+    $model->name = 'updated_fr';
+    $this->assertEquals('updated_fr', $model->name);
+    $this->assertEquals('updated_en', $model->getTranslation('name', 'en'));
+});
+
+it('can set multiple translations at once', function () {
+    $translations = ['nl' => 'hallo', 'en' => 'hello', 'kh' => 'សួរស្តី'];
+
+    $this->testModel->setTranslations('name', $translations);
+    $this->testModel->save();
+
+    $this->assertEquals($translations, $this->testModel->getTranslations('name'));
+});
+
+it('can check if an attribute is translatable', function () {
+    $this->assertTrue($this->testModel->isTranslatableAttribute('name'));
+
+    $this->assertFalse($this->testModel->isTranslatableAttribute('other'));
+});
+
+it('can check if an attribute has translation', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'nl', null);
+    $this->testModel->save();
+
+    $this->assertTrue($this->testModel->hasTranslation('name', 'en'));
+
+    $this->assertFalse($this->testModel->hasTranslation('name', 'pt'));
+});
+
+it('can correctly set a field when a mutator is defined', function () {
+    $testModel = (new class () extends TestModel {
+        public function setNameAttribute($value) {
+            $this->attributes['name'] = "I just mutated {$value}";
+        }
+    });
+
+    $testModel->name = 'hello';
+
+    $expected = ['en' => 'I just mutated hello'];
+    $this->assertEquals($expected, $testModel->getTranslations('name'));
+});
+
+it('can set multiple translations when a mutator is defined', function () {
+    $testModel = (new class () extends TestModel {
+        public function setNameAttribute($value) {
+            $this->attributes['name'] = "I just mutated {$value}";
+        }
+    });
+
+    $translations = [
+        'nl' => 'hallo',
+        'en' => 'hello',
+        'kh' => 'សួរស្តី',
+    ];
+
+    $testModel->setTranslations('name', $translations);
+
+    $testModel->save();
+
+    $expected = [
+        'nl' => 'I just mutated hallo',
+        'en' => 'I just mutated hello',
+        'kh' => 'I just mutated សួរស្តី',
+    ];
+
+    $this->assertEquals($expected, $testModel->getTranslations('name'));
+});
+
+it('can set multiple translations on field when a mutator is defined', function () {
+    $translations = [
+        'nl' => 'hallo',
+        'en' => 'hello',
+    ];
+
+    $testModel = $this->testModel;
+    $testModel->field_with_mutator = $translations;
+    $testModel->save();
+
+    $this->assertEquals($translations, $testModel->getTranslations('field_with_mutator'));
+});
+
+it('can translate a field based on the translations of another one', function () {
+    $testModel = (new class () extends TestModel {
+        public function setOtherFieldAttribute($value, $locale = 'en') {
+            $this->attributes['other_field'] = $value.' '.$this->getTranslation('name', $locale);
+        }
+    });
+
+    $testModel->setTranslations('name', [
+        'nl' => 'wereld',
+        'en' => 'world',
+    ]);
+
+    $testModel->setTranslations('other_field', [
+        'nl' => 'hallo',
+        'en' => 'hello',
+    ]);
+
+    $testModel->save();
+
+    $expected = [
+        'nl' => 'hallo wereld',
+        'en' => 'hello world',
+    ];
+
+    $this->assertEquals($expected, $testModel->getTranslations('other_field'));
+});
+
+it('handle null value from database', function () {
+    $testModel = (new class () extends TestModel {
+        public function setAttributesExternally(array $attributes) {
+            $this->attributes = $attributes;
+        }
+    });
+
+    $testModel->setAttributesExternally(['name' => json_encode(null), 'other_field' => null]);
+
+    $this->assertEquals('', $testModel->name);
+    $this->assertEquals('', $testModel->other_field);
+});
+
+it('can get all translations', function () {
+    $translations = ['nl' => 'hallo', 'en' => 'hello'];
+
+    $this->testModel->setTranslations('name', $translations);
+    $this->testModel->setTranslations('field_with_mutator', $translations);
+    $this->testModel->save();
+
+    $this->assertEquals([
+        'name' => ['nl' => 'hallo', 'en' => 'hello'],
+        'other_field' => [],
+        'field_with_mutator' => ['nl' => 'hallo', 'en' => 'hello'],
+    ], $this->testModel->translations);
+});
+
+it('will return fallback locale translation when getting an empty translation from the locale', function () {
+    config()->set('app.fallback_locale', 'en');
+
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'nl', null);
+    $this->testModel->save();
+
+    $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'nl'));
+});
+
+it('will return correct translation value if value is set to zero', function () {
+    $this->testModel->setTranslation('name', 'nl', '0');
+    $this->testModel->save();
+
+    $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
+});
+
+it('will not return fallback value if value is set to zero', function () {
+    config()->set('app.fallback_locale', 'en');
+
+    $this->testModel->setTranslation('name', 'en', '1');
+    $this->testModel->setTranslation('name', 'nl', '0');
+    $this->testModel->save();
+
+    $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
+});
+
+it('will not remove zero value of other locale in database', function () {
+    config()->set('app.fallback_locale', 'en');
+
+    $this->testModel->setTranslation('name', 'nl', '0');
+    $this->testModel->setTranslation('name', 'en', '1');
+    $this->testModel->save();
+
+    $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
+});
+
+it('can be translated based on given locale', function () {
+    $value = 'World';
+
+    $this->testModel = TestModel::usingLocale('en')->fill([
+        'name' => $value,
+    ]);
+    $this->testModel->save();
+
+    $this->assertSame($value, $this->testModel->getTranslation('name', 'en'));
+});
+
+it('can set and fetch attributes based on set locale', function () {
+    $en = 'World';
+    $fr = 'Monde';
+
+    $this->testModel->setLocale('en');
+    $this->testModel->name = $en;
+    $this->testModel->setLocale('fr');
+    $this->testModel->name = $fr;
+
+    $this->testModel->save();
+
+    $this->testModel->setLocale('en');
+    $this->assertSame($en, $this->testModel->name);
+    $this->testModel->setLocale('fr');
+    $this->assertSame($fr, $this->testModel->name);
+});
+
+it('can replace translations', function () {
+    $translations = ['nl' => 'hallo', 'en' => 'hello', 'kh' => 'សួរស្តី'];
+
+    $this->testModel->setTranslations('name', $translations);
+    $this->testModel->save();
+
+    $newTranslations = ['es' => 'hola'];
+    $this->testModel->replaceTranslations('name', $newTranslations);
+
+    $this->assertEquals($newTranslations, $this->testModel->getTranslations('name'));
+});
+
+it('can use any locale if given locale not set', function () {
+    config()->set('app.fallback_locale', 'en');
+
+    Translatable::fallback(
+        fallbackAny: true,
+    );
+
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->setTranslation('name', 'de', 'testValue_de');
+    $this->testModel->save();
+
+    $this->testModel->setLocale('it');
+    $this->assertSame('testValue_fr', $this->testModel->name);
+});
+
+it('will return set translation when fallback any set', function () {
+    config()->set('app.fallback_locale', 'en');
+
+    Translatable::fallback(
+        fallbackAny: true,
+    );
+
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->setTranslation('name', 'de', 'testValue_de');
+    $this->testModel->save();
+
+    $this->testModel->setLocale('de');
+    $this->assertSame('testValue_de', $this->testModel->name);
+});
+
+it('will return fallback translation when fallback any set', function () {
+    config()->set('app.fallback_locale', 'en');
+
+    Translatable::fallback(
+        fallbackAny: true,
+    );
+
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
+
+    $this->testModel->setLocale('de');
+    $this->assertSame('testValue_en', $this->testModel->name);
+});
+
+it('provides a flog to not return any translation when getting an unknown locale', function () {
+    config()->set('app.fallback_locale', 'en');
+
+    Translatable::fallback(
+        fallbackAny: true,
+    );
+
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->setTranslation('name', 'de', 'testValue_de');
+    $this->testModel->save();
+
+    $this->testModel->setLocale('it');
+    $this->assertSame('', $this->testModel->getTranslation('name', 'it', false));
+});
+
+it('will return default fallback locale translation when getting an unknown locale with fallback any', function () {
+    config()->set('app.fallback_locale', 'en');
+
+    Translatable::fallback(
+        fallbackAny: true,
+    );
+
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->save();
+
+    $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'fr'));
+});

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -397,7 +397,8 @@ it('can use accessors on translated attributes', function () {
 
 it('can use mutators on translated attributes', function () {
     $testModel = new class () extends TestModel {
-        public function setNameAttribute($value) {
+        public function setNameAttribute($value)
+        {
             $this->attributes['name'] = "I just mutated {$value}";
         }
     };
@@ -454,7 +455,8 @@ it('can check if an attribute has translation', function () {
 
 it('can correctly set a field when a mutator is defined', function () {
     $testModel = (new class () extends TestModel {
-        public function setNameAttribute($value) {
+        public function setNameAttribute($value)
+        {
             $this->attributes['name'] = "I just mutated {$value}";
         }
     });
@@ -467,7 +469,8 @@ it('can correctly set a field when a mutator is defined', function () {
 
 it('can set multiple translations when a mutator is defined', function () {
     $testModel = (new class () extends TestModel {
-        public function setNameAttribute($value) {
+        public function setNameAttribute($value)
+        {
             $this->attributes['name'] = "I just mutated {$value}";
         }
     });
@@ -506,7 +509,8 @@ it('can set multiple translations on field when a mutator is defined', function 
 
 it('can translate a field based on the translations of another one', function () {
     $testModel = (new class () extends TestModel {
-        public function setOtherFieldAttribute($value, $locale = 'en') {
+        public function setOtherFieldAttribute($value, $locale = 'en')
+        {
             $this->attributes['other_field'] = $value.' '.$this->getTranslation('name', $locale);
         }
     });
@@ -533,7 +537,8 @@ it('can translate a field based on the translations of another one', function ()
 
 it('handle null value from database', function () {
     $testModel = (new class () extends TestModel {
-        public function setAttributesExternally(array $attributes) {
+        public function setAttributesExternally(array $attributes)
+        {
             $this->attributes = $attributes;
         }
     });

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -3,8 +3,7 @@
 use Illuminate\Support\Facades\Storage;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 use Spatie\Translatable\Facades\Translatable;
-
-uses(TestCase::class);
+use Spatie\Translatable\Test\TestSupport\TestModel;
 
 beforeEach(function () {
     $this->testModel = new TestModel();

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -19,7 +19,7 @@ it('will return package fallback locale translation when getting an unknown loca
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'fr'));
+    expect($this->testModel->getTranslation('name', 'fr'))->toBe('testValue_en');
 });
 
 it('will return default fallback locale translation when getting an unknown locale', function () {
@@ -28,7 +28,7 @@ it('will return default fallback locale translation when getting an unknown loca
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'fr'));
+    expect($this->testModel->getTranslation('name', 'fr'))->toBe('testValue_en');
 });
 
 it('provides a flog to not return fallback locale translation when getting an unknown locale', function () {
@@ -37,7 +37,7 @@ it('provides a flog to not return fallback locale translation when getting an un
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('', $this->testModel->getTranslation('name', 'fr', false));
+    expect($this->testModel->getTranslation('name', 'fr', false))->toBe('');
 });
 
 it('will return fallback locale translation when getting an unknown locale and fallback is true', function () {
@@ -46,7 +46,7 @@ it('will return fallback locale translation when getting an unknown locale and f
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
+    expect($this->testModel->getTranslationWithFallback('name', 'fr'))->toBe('testValue_en');
 });
 
 it('will execute callback fallback when getting an unknown locale and fallback callback is enabled', function () {
@@ -60,7 +60,7 @@ it('will execute callback fallback when getting an unknown locale and fallback c
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
+    expect($this->testModel->getTranslationWithFallback('name', 'fr'))->toBe('testValue_en');
 
     Storage::assertExists("test.txt");
 });
@@ -73,7 +73,7 @@ it('will use callback fallback return value as translation', function () {
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('testValue_fallback_callback', $this->testModel->getTranslationWithFallback('name', 'fr'));
+    expect($this->testModel->getTranslationWithFallback('name', 'fr'))->toBe('testValue_fallback_callback');
 });
 
 it('wont use callback fallback return value as translation if it is not a string', function () {
@@ -84,7 +84,7 @@ it('wont use callback fallback return value as translation if it is not a string
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
+    expect($this->testModel->getTranslationWithFallback('name', 'fr'))->toBe('testValue_en');
 });
 
 it('wont execute callback fallback when getting an existing translation', function () {
@@ -98,7 +98,7 @@ it('wont execute callback fallback when getting an existing translation', functi
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'en'));
+    expect($this->testModel->getTranslationWithFallback('name', 'en'))->toBe('testValue_en');
 
     Storage::assertMissing("test.txt");
 });
@@ -111,7 +111,7 @@ it('wont fail if callback fallback throw exception', function () {
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('testValue_en', $this->testModel->getTranslationWithFallback('name', 'fr'));
+    expect($this->testModel->getTranslationWithFallback('name', 'fr'))->toBe('testValue_en');
 });
 
 it('will return an empty string when getting an unknown locale and fallback is not set', function () {
@@ -124,7 +124,7 @@ it('will return an empty string when getting an unknown locale and fallback is n
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('', $this->testModel->getTranslationWithoutFallback('name', 'fr'));
+    expect($this->testModel->getTranslationWithoutFallback('name', 'fr'))->toBe('');
 });
 
 it('will return an empty string when getting an unknown locale and fallback is empty', function () {
@@ -137,14 +137,14 @@ it('will return an empty string when getting an unknown locale and fallback is e
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('', $this->testModel->getTranslation('name', 'fr'));
+    expect($this->testModel->getTranslation('name', 'fr'))->toBe('');
 });
 
 it('can save a translated attribute', function () {
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('testValue_en', $this->testModel->name);
+    expect($this->testModel->name)->toBe('testValue_en');
 });
 
 it('can set translated values when creating a model', function () {
@@ -152,7 +152,7 @@ it('can set translated values when creating a model', function () {
         'name' => ['en' => 'testValue_en'],
     ]);
 
-    $this->assertSame('testValue_en', $model->name);
+    expect($model->name)->toBe('testValue_en');
 });
 
 it('can save multiple translations', function () {
@@ -160,8 +160,8 @@ it('can save multiple translations', function () {
     $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
     $this->testModel->save();
 
-    $this->assertSame('testValue_en', $this->testModel->name);
-    $this->assertSame('testValue_fr', $this->testModel->getTranslation('name', 'fr'));
+    expect($this->testModel->name)->toBe('testValue_en');
+    expect($this->testModel->getTranslation('name', 'fr'))->toBe('testValue_fr');
 });
 
 it('will return the value of the current locale when using the property', function () {
@@ -171,7 +171,7 @@ it('will return the value of the current locale when using the property', functi
 
     app()->setLocale('fr');
 
-    $this->assertSame('testValue_fr', $this->testModel->name);
+    expect($this->testModel->name)->toBe('testValue_fr');
 });
 
 it('can get all translations in one go', function () {
@@ -245,7 +245,7 @@ it('can get the locales which have a translation', function () {
     $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
     $this->testModel->save();
 
-    $this->assertSame(['en', 'fr'], $this->testModel->getTranslatedLocales('name'));
+    expect($this->testModel->getTranslatedLocales('name'))->toBe(['en', 'fr']);
 });
 
 it('can forget a translation', function () {
@@ -277,13 +277,13 @@ it('can forget all translations of field', function () {
 
     $this->testModel->forgetTranslations('name');
 
-    $this->assertSame('[]', $this->testModel->getAttributes()['name']);
-    $this->assertSame([], $this->testModel->getTranslations('name'));
+    expect($this->testModel->getAttributes()['name'])->toBe('[]');
+    expect($this->testModel->getTranslations('name'))->toBe([]);
 
     $this->testModel->save();
 
-    $this->assertSame('[]', $this->testModel->fresh()->getAttributes()['name']);
-    $this->assertSame([], $this->testModel->fresh()->getTranslations('name'));
+    expect($this->testModel->fresh()->getAttributes()['name'])->toBe('[]');
+    expect($this->testModel->fresh()->getTranslations('name'))->toBe([]);
 });
 
 it('can forget all translations of field and make field null', function () {
@@ -298,13 +298,13 @@ it('can forget all translations of field and make field null', function () {
 
     $this->testModel->forgetTranslations('name', true);
 
-    $this->assertNull($this->testModel->getAttributes()['name']);
-    $this->assertSame([], $this->testModel->getTranslations('name'));
+    expect($this->testModel->getAttributes()['name'])->toBeNull();
+    expect($this->testModel->getTranslations('name'))->toBe([]);
 
     $this->testModel->save();
 
-    $this->assertNull($this->testModel->fresh()->getAttributes()['name']);
-    $this->assertSame([], $this->testModel->fresh()->getTranslations('name'));
+    expect($this->testModel->fresh()->getAttributes()['name'])->toBeNull();
+    expect($this->testModel->fresh()->getTranslations('name'))->toBe([]);
 });
 
 it('can forget a field with mutator translation', function () {
@@ -379,7 +379,7 @@ it('is compatible with accessors on non translatable attributes', function () {
         }
     };
 
-    $this->assertEquals((new $testModel())->otherField, 'accessorName');
+    expect('accessorName')->toEqual((new $testModel())->otherField);
 });
 
 it('can use accessors on translated attributes', function () {
@@ -392,7 +392,7 @@ it('can use accessors on translated attributes', function () {
 
     $testModel->setTranslation('name', 'en', 'testValue_en');
 
-    $this->assertEquals($testModel->name, 'I just accessed testValue_en');
+    expect('I just accessed testValue_en')->toEqual($testModel->name);
 });
 
 it('can use mutators on translated attributes', function () {
@@ -404,7 +404,7 @@ it('can use mutators on translated attributes', function () {
 
     $testModel->setTranslation('name', 'en', 'testValue_en');
 
-    $this->assertEquals($testModel->name, 'I just mutated testValue_en');
+    expect('I just mutated testValue_en')->toEqual($testModel->name);
 });
 
 it('can set translations for default language', function () {
@@ -418,13 +418,13 @@ it('can set translations for default language', function () {
     app()->setLocale('en');
 
     $model->name = 'updated_en';
-    $this->assertEquals('updated_en', $model->name);
-    $this->assertEquals('testValue_fr', $model->getTranslation('name', 'fr'));
+    expect($model->name)->toEqual('updated_en');
+    expect($model->getTranslation('name', 'fr'))->toEqual('testValue_fr');
 
     app()->setLocale('fr');
     $model->name = 'updated_fr';
-    $this->assertEquals('updated_fr', $model->name);
-    $this->assertEquals('updated_en', $model->getTranslation('name', 'en'));
+    expect($model->name)->toEqual('updated_fr');
+    expect($model->getTranslation('name', 'en'))->toEqual('updated_en');
 });
 
 it('can set multiple translations at once', function () {
@@ -433,13 +433,13 @@ it('can set multiple translations at once', function () {
     $this->testModel->setTranslations('name', $translations);
     $this->testModel->save();
 
-    $this->assertEquals($translations, $this->testModel->getTranslations('name'));
+    expect($this->testModel->getTranslations('name'))->toEqual($translations);
 });
 
 it('can check if an attribute is translatable', function () {
-    $this->assertTrue($this->testModel->isTranslatableAttribute('name'));
+    expect($this->testModel->isTranslatableAttribute('name'))->toBeTrue();
 
-    $this->assertFalse($this->testModel->isTranslatableAttribute('other'));
+    expect($this->testModel->isTranslatableAttribute('other'))->toBeFalse();
 });
 
 it('can check if an attribute has translation', function () {
@@ -447,9 +447,9 @@ it('can check if an attribute has translation', function () {
     $this->testModel->setTranslation('name', 'nl', null);
     $this->testModel->save();
 
-    $this->assertTrue($this->testModel->hasTranslation('name', 'en'));
+    expect($this->testModel->hasTranslation('name', 'en'))->toBeTrue();
 
-    $this->assertFalse($this->testModel->hasTranslation('name', 'pt'));
+    expect($this->testModel->hasTranslation('name', 'pt'))->toBeFalse();
 });
 
 it('can correctly set a field when a mutator is defined', function () {
@@ -462,7 +462,7 @@ it('can correctly set a field when a mutator is defined', function () {
     $testModel->name = 'hello';
 
     $expected = ['en' => 'I just mutated hello'];
-    $this->assertEquals($expected, $testModel->getTranslations('name'));
+    expect($testModel->getTranslations('name'))->toEqual($expected);
 });
 
 it('can set multiple translations when a mutator is defined', function () {
@@ -488,7 +488,7 @@ it('can set multiple translations when a mutator is defined', function () {
         'kh' => 'I just mutated សួរស្តី',
     ];
 
-    $this->assertEquals($expected, $testModel->getTranslations('name'));
+    expect($testModel->getTranslations('name'))->toEqual($expected);
 });
 
 it('can set multiple translations on field when a mutator is defined', function () {
@@ -501,7 +501,7 @@ it('can set multiple translations on field when a mutator is defined', function 
     $testModel->field_with_mutator = $translations;
     $testModel->save();
 
-    $this->assertEquals($translations, $testModel->getTranslations('field_with_mutator'));
+    expect($testModel->getTranslations('field_with_mutator'))->toEqual($translations);
 });
 
 it('can translate a field based on the translations of another one', function () {
@@ -528,7 +528,7 @@ it('can translate a field based on the translations of another one', function ()
         'en' => 'hello world',
     ];
 
-    $this->assertEquals($expected, $testModel->getTranslations('other_field'));
+    expect($testModel->getTranslations('other_field'))->toEqual($expected);
 });
 
 it('handle null value from database', function () {
@@ -540,8 +540,8 @@ it('handle null value from database', function () {
 
     $testModel->setAttributesExternally(['name' => json_encode(null), 'other_field' => null]);
 
-    $this->assertEquals('', $testModel->name);
-    $this->assertEquals('', $testModel->other_field);
+    expect($testModel->name)->toEqual('');
+    expect($testModel->other_field)->toEqual('');
 });
 
 it('can get all translations', function () {
@@ -565,14 +565,14 @@ it('will return fallback locale translation when getting an empty translation fr
     $this->testModel->setTranslation('name', 'nl', null);
     $this->testModel->save();
 
-    $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'nl'));
+    expect($this->testModel->getTranslation('name', 'nl'))->toBe('testValue_en');
 });
 
 it('will return correct translation value if value is set to zero', function () {
     $this->testModel->setTranslation('name', 'nl', '0');
     $this->testModel->save();
 
-    $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
+    expect($this->testModel->getTranslation('name', 'nl'))->toBe('0');
 });
 
 it('will not return fallback value if value is set to zero', function () {
@@ -582,7 +582,7 @@ it('will not return fallback value if value is set to zero', function () {
     $this->testModel->setTranslation('name', 'nl', '0');
     $this->testModel->save();
 
-    $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
+    expect($this->testModel->getTranslation('name', 'nl'))->toBe('0');
 });
 
 it('will not remove zero value of other locale in database', function () {
@@ -592,7 +592,7 @@ it('will not remove zero value of other locale in database', function () {
     $this->testModel->setTranslation('name', 'en', '1');
     $this->testModel->save();
 
-    $this->assertSame('0', $this->testModel->getTranslation('name', 'nl'));
+    expect($this->testModel->getTranslation('name', 'nl'))->toBe('0');
 });
 
 it('can be translated based on given locale', function () {
@@ -603,7 +603,7 @@ it('can be translated based on given locale', function () {
     ]);
     $this->testModel->save();
 
-    $this->assertSame($value, $this->testModel->getTranslation('name', 'en'));
+    expect($this->testModel->getTranslation('name', 'en'))->toBe($value);
 });
 
 it('can set and fetch attributes based on set locale', function () {
@@ -618,9 +618,9 @@ it('can set and fetch attributes based on set locale', function () {
     $this->testModel->save();
 
     $this->testModel->setLocale('en');
-    $this->assertSame($en, $this->testModel->name);
+    expect($this->testModel->name)->toBe($en);
     $this->testModel->setLocale('fr');
-    $this->assertSame($fr, $this->testModel->name);
+    expect($this->testModel->name)->toBe($fr);
 });
 
 it('can replace translations', function () {
@@ -632,7 +632,7 @@ it('can replace translations', function () {
     $newTranslations = ['es' => 'hola'];
     $this->testModel->replaceTranslations('name', $newTranslations);
 
-    $this->assertEquals($newTranslations, $this->testModel->getTranslations('name'));
+    expect($this->testModel->getTranslations('name'))->toEqual($newTranslations);
 });
 
 it('can use any locale if given locale not set', function () {
@@ -647,7 +647,7 @@ it('can use any locale if given locale not set', function () {
     $this->testModel->save();
 
     $this->testModel->setLocale('it');
-    $this->assertSame('testValue_fr', $this->testModel->name);
+    expect($this->testModel->name)->toBe('testValue_fr');
 });
 
 it('will return set translation when fallback any set', function () {
@@ -662,7 +662,7 @@ it('will return set translation when fallback any set', function () {
     $this->testModel->save();
 
     $this->testModel->setLocale('de');
-    $this->assertSame('testValue_de', $this->testModel->name);
+    expect($this->testModel->name)->toBe('testValue_de');
 });
 
 it('will return fallback translation when fallback any set', function () {
@@ -677,7 +677,7 @@ it('will return fallback translation when fallback any set', function () {
     $this->testModel->save();
 
     $this->testModel->setLocale('de');
-    $this->assertSame('testValue_en', $this->testModel->name);
+    expect($this->testModel->name)->toBe('testValue_en');
 });
 
 it('provides a flog to not return any translation when getting an unknown locale', function () {
@@ -692,7 +692,7 @@ it('provides a flog to not return any translation when getting an unknown locale
     $this->testModel->save();
 
     $this->testModel->setLocale('it');
-    $this->assertSame('', $this->testModel->getTranslation('name', 'it', false));
+    expect($this->testModel->getTranslation('name', 'it', false))->toBe('');
 });
 
 it('will return default fallback locale translation when getting an unknown locale with fallback any', function () {
@@ -705,5 +705,5 @@ it('will return default fallback locale translation when getting an unknown loca
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    $this->assertSame('testValue_en', $this->testModel->getTranslation('name', 'fr'));
+    expect($this->testModel->getTranslation('name', 'fr'))->toBe('testValue_en');
 });


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-57946` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
