### PR TITLE
Fix typo in "Getting and setting translations"

### DIFF
--- a/docs/basic-usage/getting-and-settings-translations.md
+++ b/docs/basic-usage/getting-and-settings-translations.md
@@ -47,7 +47,7 @@ $newItem->name = $translations;
 
 // alternatively, use the `setTranslations` method
 
-$newsItem->setTranslations('hello', $translations);
+$newsItem->setTranslations('name', $translations);
 
 $newItem->save();
 ```


### PR DESCRIPTION
There is a typo in documentation example. The attribute name is "name", not "hello". This PR fix it.