### PR TITLE
Fixed example for forgetAllTranslations() method.

### DIFF
--- a/docs/basic-usage/removing-translations.md
+++ b/docs/basic-usage/removing-translations.md
@@ -24,5 +24,5 @@ public function forgetAllTranslations(string $locale)
 Here's an example:
 
 ```php
-$newsItem->forgetTranslation('name');
+$newsItem->forgetAllTranslations('nl');
 ```


### PR DESCRIPTION
The example given did not demonstrate usage of the forgetAllTranslations() method.