### PR TITLE
Add new scope for search in the translations column 

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -161,7 +161,7 @@ trait HasTranslations
         return $this;
     }
     
-    public function scopeContaining(Builder $query, string $column, string $value, $locale = null): Builder
+    public function scopeWhereTranslationLike(Builder $query, string $column, string $value, $locale = null): Builder
     {
         $this->guardAgainstNonTranslatableAttribute($column);
 

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Str;
 use Spatie\Translatable\Events\TranslationHasBeenSetEvent;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
+use Illuminate\Database\Eloquent\Builder;
 
 trait HasTranslations
 {
@@ -158,6 +159,15 @@ trait HasTranslations
         $this->setTranslations($key, $translations);
 
         return $this;
+    }
+    
+    public function scopeContaining(Builder $query, string $column, string $value, $locale = null): Builder
+    {
+        $this->guardAgainstNonTranslatableAttribute($column);
+
+        $locale = $locale ?? $this->getLocale();
+
+        return $query->whereRaw('lower(' . $this->getQuery()->getGrammar()->wrap($column . '->' . $locale) . ') like ?', [$value]);
     }
 
     public function forgetTranslations(string $key, bool $asNull = false): self


### PR DESCRIPTION
Can be used:

```php
$categories = Category::query()
    ->when($request->search, function ($query, $search) {
        return $query->whereTranslationLike('name', "%$search%");
    })
    ->get();
```