### PR TITLE
Added whereLocale and whereLocales methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ $newsItem->getTranslation('name', 'nl'); // returns 'Naam in het Nederlands'
 app()->setLocale('nl');
 
 $newsItem->name; // Returns 'Naam in het Nederlands'
+
+// If you want to query records based on locales, you can use the `whereLocale` and `whereLocales` methods.
+
+NewsItem::whereLocale('name', 'en')->get(); // Returns all news items with a name in English
+
+NewsItem::whereLocales('name', ['en', 'nl'])->get(); // Returns all news items with a name in English or Dutch
 ```
 
 ## Support us

--- a/docs/basic-usage/getting-and-settings-translations.md
+++ b/docs/basic-usage/getting-and-settings-translations.md
@@ -109,3 +109,15 @@ $translations = [
 $newsItem->setTranslations('hello', $translations);
 $newsItem->getTranslations('hello', ['en', 'fr']); // returns ['en' => 'Hello', 'fr' => 'Bonjour']
 ```
+
+### Get locales that a model has
+
+You can get all locales that a model has by calling `locales()` without an argument:
+
+```php
+   $translations = ['en' => 'hello', 'es' => 'hola'];
+   $newItem->name = $translations;
+   $newItem->save();
+
+   $newItem->locales(); // returns ['en', 'es']
+```

--- a/docs/basic-usage/querying-translations.md
+++ b/docs/basic-usage/querying-translations.md
@@ -14,3 +14,11 @@ Or if you're using MariaDB 10.2.3 or above :
 ```php
 NewsItem::whereRaw("JSON_EXTRACT(name, '$.en') = 'Name in English'")->get();
 ```
+
+If you want to query records based on locales, you can use the `whereLocale` and `whereLocales` methods.
+
+```php
+NewsItem::whereLocale('name', 'en')->get(); // Returns all news items with a name in English
+
+NewsItem::whereLocales('name', ['en', 'nl'])->get(); // Returns all news items with a name in English or Dutch
+```

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -3,6 +3,7 @@
 namespace Spatie\Translatable;
 
 use Exception;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Str;
 use Spatie\Translatable\Events\TranslationHasBeenSetEvent;
@@ -312,5 +313,19 @@ trait HasTranslations
                 return array_merge($result, $this->getTranslatedLocales($item));
             }, [])
         );
+    }
+
+    public static function whereLocale(string $column, string $locale): Builder
+    {
+        return static::query()->whereNotNull("{$column}->{$locale}");
+    }
+
+    public static function whereLocales(string $column, array $locales): Builder
+    {
+        return static::query()->where(function (Builder $query) use ($column, $locales) {
+            foreach ($locales as $locale) {
+                $query->orWhereNotNull("{$column}->{$locale}");
+            }
+        });
     }
 }

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -304,4 +304,13 @@ trait HasTranslations
             array_fill_keys($this->getTranslatableAttributes(), 'array'),
         );
     }
+
+    public function locales(): array
+    {
+        return array_unique(
+            array_reduce($this->getTranslatableAttributes(), function ($result, $item) {
+                return array_merge($result, $this->getTranslatedLocales($item));
+            }, [])
+        );
+    }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -371,7 +371,8 @@ it('will throw an exception when trying to translate an untranslatable attribute
 });
 
 it('is compatible with accessors on non translatable attributes', function () {
-    $testModel = new class () extends TestModel {
+    $testModel = new class() extends TestModel
+    {
         public function getOtherFieldAttribute(): string
         {
             return 'accessorName';
@@ -382,7 +383,8 @@ it('is compatible with accessors on non translatable attributes', function () {
 });
 
 it('can use accessors on translated attributes', function () {
-    $testModel = new class () extends TestModel {
+    $testModel = new class() extends TestModel
+    {
         public function getNameAttribute($value): string
         {
             return "I just accessed {$value}";
@@ -395,7 +397,8 @@ it('can use accessors on translated attributes', function () {
 });
 
 it('can use mutators on translated attributes', function () {
-    $testModel = new class () extends TestModel {
+    $testModel = new class() extends TestModel
+    {
         public function setNameAttribute($value)
         {
             $this->attributes['name'] = "I just mutated {$value}";
@@ -453,7 +456,8 @@ it('can check if an attribute has translation', function () {
 });
 
 it('can correctly set a field when a mutator is defined', function () {
-    $testModel = (new class () extends TestModel {
+    $testModel = (new class() extends TestModel
+    {
         public function setNameAttribute($value)
         {
             $this->attributes['name'] = "I just mutated {$value}";
@@ -467,7 +471,8 @@ it('can correctly set a field when a mutator is defined', function () {
 });
 
 it('can set multiple translations when a mutator is defined', function () {
-    $testModel = (new class () extends TestModel {
+    $testModel = (new class() extends TestModel
+    {
         public function setNameAttribute($value)
         {
             $this->attributes['name'] = "I just mutated {$value}";
@@ -507,10 +512,11 @@ it('can set multiple translations on field when a mutator is defined', function 
 });
 
 it('can translate a field based on the translations of another one', function () {
-    $testModel = (new class () extends TestModel {
+    $testModel = (new class() extends TestModel
+    {
         public function setOtherFieldAttribute($value, $locale = 'en')
         {
-            $this->attributes['other_field'] = $value.' '.$this->getTranslation('name', $locale);
+            $this->attributes['other_field'] = $value . ' ' . $this->getTranslation('name', $locale);
         }
     });
 
@@ -535,7 +541,8 @@ it('can translate a field based on the translations of another one', function ()
 });
 
 it('handle null value from database', function () {
-    $testModel = (new class () extends TestModel {
+    $testModel = (new class() extends TestModel
+    {
         public function setAttributesExternally(array $attributes)
         {
             $this->attributes = $attributes;
@@ -710,4 +717,17 @@ it('will return default fallback locale translation when getting an unknown loca
     $this->testModel->save();
 
     expect($this->testModel->getTranslation('name', 'fr'))->toBe('testValue_en');
+});
+
+it('will return all locales when getting all translations', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->setTranslation('name', 'tr', 'testValue_tr');
+    $this->testModel->save();
+
+    expect($this->testModel->locales())->toEqual([
+        'en',
+        'fr',
+        'tr',
+    ]);
 });

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -371,8 +371,7 @@ it('will throw an exception when trying to translate an untranslatable attribute
 });
 
 it('is compatible with accessors on non translatable attributes', function () {
-    $testModel = new class() extends TestModel
-    {
+    $testModel = new class () extends TestModel {
         public function getOtherFieldAttribute(): string
         {
             return 'accessorName';
@@ -383,8 +382,7 @@ it('is compatible with accessors on non translatable attributes', function () {
 });
 
 it('can use accessors on translated attributes', function () {
-    $testModel = new class() extends TestModel
-    {
+    $testModel = new class () extends TestModel {
         public function getNameAttribute($value): string
         {
             return "I just accessed {$value}";
@@ -397,8 +395,7 @@ it('can use accessors on translated attributes', function () {
 });
 
 it('can use mutators on translated attributes', function () {
-    $testModel = new class() extends TestModel
-    {
+    $testModel = new class () extends TestModel {
         public function setNameAttribute($value)
         {
             $this->attributes['name'] = "I just mutated {$value}";
@@ -456,8 +453,7 @@ it('can check if an attribute has translation', function () {
 });
 
 it('can correctly set a field when a mutator is defined', function () {
-    $testModel = (new class() extends TestModel
-    {
+    $testModel = (new class () extends TestModel {
         public function setNameAttribute($value)
         {
             $this->attributes['name'] = "I just mutated {$value}";
@@ -471,8 +467,7 @@ it('can correctly set a field when a mutator is defined', function () {
 });
 
 it('can set multiple translations when a mutator is defined', function () {
-    $testModel = (new class() extends TestModel
-    {
+    $testModel = (new class () extends TestModel {
         public function setNameAttribute($value)
         {
             $this->attributes['name'] = "I just mutated {$value}";
@@ -512,8 +507,7 @@ it('can set multiple translations on field when a mutator is defined', function 
 });
 
 it('can translate a field based on the translations of another one', function () {
-    $testModel = (new class() extends TestModel
-    {
+    $testModel = (new class () extends TestModel {
         public function setOtherFieldAttribute($value, $locale = 'en')
         {
             $this->attributes['other_field'] = $value . ' ' . $this->getTranslation('name', $locale);
@@ -541,8 +535,7 @@ it('can translate a field based on the translations of another one', function ()
 });
 
 it('handle null value from database', function () {
-    $testModel = (new class() extends TestModel
-    {
+    $testModel = (new class () extends TestModel {
         public function setAttributesExternally(array $attributes)
         {
             $this->attributes = $attributes;

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -724,3 +724,25 @@ it('will return all locales when getting all translations', function () {
         'tr',
     ]);
 });
+
+it('queries the database whether a locale exists', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->setTranslation('name', 'tr', 'testValue_tr');
+    $this->testModel->save();
+
+    expect($this->testModel->whereLocale('name', 'en')->get())->toHaveCount(1);
+
+    expect($this->testModel->whereLocale('name', 'de')->get())->toHaveCount(0);
+});
+
+it('queries the database for multiple locales', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->setTranslation('name', 'tr', 'testValue_tr');
+    $this->testModel->save();
+
+    expect($this->testModel->whereLocales('name', ['en', 'tr'])->get())->toHaveCount(1);
+
+    expect($this->testModel->whereLocales('name', ['de', 'be'])->get())->toHaveCount(0);
+});


### PR DESCRIPTION
In some cases, there are times when I want to extract content according to the user's locale, and in this case, I found these solutions instead of constantly writing queries.

`whereLocale` and `whereLocales` methods.

```php
$post->whereLocale('title', 'en')->get();

// or mutliple locales
$post->whereLocales('title', ['en', 'fr'])->get();
```