### PR TITLE
Added hasTranslatedColumn scope

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -328,4 +328,13 @@ trait HasTranslations
             }
         });
     }
+
+    public function scopeHasTranslatedColumn(Builder $query, string $column, string $value, array $locales, string $operand = '='): Builder
+	{
+		return $query->where(function (Builder $query) use ($column, $locales, $operand, $value): void {
+			foreach ($locales as $locale) {
+				$query->orWhere("{$column}->{$locale}", $operand, $value);
+			}
+		});
+	}
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -746,3 +746,16 @@ it('queries the database for multiple locales', function () {
 
     expect($this->testModel->whereLocales('name', ['de', 'be'])->get())->toHaveCount(0);
 });
+
+it('queries the database with hasTranslatedColumn scope', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->setTranslation('name', 'tr', 'testValue_tr');
+    $this->testModel->save();
+
+    expect(TestModel::hasTranslatedColumn('name', 'testValue_en', ['en', 'fr', 'tr'])->get())->toHaveCount(1);
+
+    expect($this->testModel->whereLocales('name', 'testValue_en', ['de', 'be'])->get())->toHaveCount(0);
+
+    expect(TestModel::hasTranslatedColumn('name', 'testVal%', ['en', 'fr', 'tr'], 'like')->get())->toHaveCount(1);
+});


### PR DESCRIPTION
Recently I needed to query a translated model column by a value from request. I didn't found a way to do it directly so I've done something like this. Hope you find it useful...

We can now query a model by translated column with a value... eg:

```php
// PostController
public function getSinglePost(string $slug)
{
    return Post::hasTranslatedColumn('slug', $slug, ['en', 'de'])->firstOrFail();
}
```

Or we can also search it via `like` query:

```php
Post::hasTranslatedColumn('title', $request->search, ['en', 'de'], 'like')->firstOrFail();
```

Method `hasTranslatedColumn` is actually a Laravel scope so you can chain it to any other `Builder` methods like so:

```php
Post::where('published', true)
    ->hasTranslatedColumn('title', $request->search, ['en', 'de'], 'like')
    ->latest()
    ->get();
```

PS: I'm not a 100% sure about the scope naming so we can adjust that to a better one...  :)