### PR TITLE
Enable fallback locale on a per model basis

### DIFF
--- a/docs/basic-usage/handling-missing-translations.md
+++ b/docs/basic-usage/handling-missing-translations.md
@@ -97,3 +97,22 @@ Translatable::fallback(missingKeyCallback: function (
     return MyRemoteTranslationService::getAutomaticTranslation($fallbackTranslation, $fallbackLocale, $locale);
 });
 ```
+
+### Disabling fallbacks on a per model basis
+By default, a fallback will be used when you access a non-existent translation attribute.
+
+You can disable fallbacks on a model with the `$useFallbackLocale` property.
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\HasTranslations;
+
+class NewsItem extends Model
+{
+    use HasTranslations;
+
+    public $translatable = ['name'];
+    
+    protected $useFallbackLocale = false;
+}
+```

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -18,13 +18,22 @@ trait HasTranslations
         return (new self())->setLocale($locale);
     }
 
+    public function useFallbackLocale(): bool
+    {
+        if (property_exists($this, 'useFallbackLocale')) {
+            return $this->useFallbackLocale;
+        }
+
+        return true;
+    }
+
     public function getAttributeValue($key): mixed
     {
         if (! $this->isTranslatableAttribute($key)) {
             return parent::getAttributeValue($key);
         }
 
-        return $this->getTranslation($key, $this->getLocale());
+        return $this->getTranslation($key, $this->getLocale(), $this->useFallbackLocale());
     }
 
     public function setAttribute($key, $value)

--- a/tests/TestSupport/TestModelWithoutFallback.php
+++ b/tests/TestSupport/TestModelWithoutFallback.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\Translatable\Test\TestSupport;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\HasTranslations;
+
+class TestModelWithoutFallback extends Model
+{
+    use HasTranslations;
+
+    protected $table = 'test_models';
+
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public $translatable = ['name', 'other_field', 'field_with_mutator'];
+
+    protected $useFallbackLocale = false;
+
+    public function setFieldWithMutatorAttribute($value)
+    {
+        $this->attributes['field_with_mutator'] = $value;
+    }
+}

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Storage;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 use Spatie\Translatable\Facades\Translatable;
 use Spatie\Translatable\Test\TestSupport\TestModel;
+use Spatie\Translatable\Test\TestSupport\TestModelWithoutFallback;
 
 beforeEach(function () {
     $this->testModel = new TestModel();
@@ -745,4 +746,17 @@ it('queries the database for multiple locales', function () {
     expect($this->testModel->whereLocales('name', ['en', 'tr'])->get())->toHaveCount(1);
 
     expect($this->testModel->whereLocales('name', ['de', 'be'])->get())->toHaveCount(0);
+});
+
+it('can disable attribute locale fallback on a per model basis', function () {
+    config()->set('app.fallback_locale', 'en');
+
+    $model = new TestModelWithoutFallback();
+
+    $model->setTranslation('name', 'en', 'testValue_en');
+    $model->save();
+
+    $model->setLocale('fr');
+
+    expect($model->name)->toBe('');
 });


### PR DESCRIPTION
In our project we use this package on multiple models. Almost all of them need a fallback language except a new one. We access the attribute using `$model->translatableAttribute` but this always uses the fallback language.

PR adds the possibility to add a `useFallbackLocale` property to the model.

```php
class Article extends Model
{
    use HasTranslations;

    protected $useFallbackLocale = false;
}
``` 

This was my solution without this PR:

```php
Translatable::fallback(missingKeyCallback: function (
    Model $model,
    string $translationKey,
    string $locale,
    string $fallbackTranslation,
    string $fallbackLocale,
) {
    if ($model instanceof NewsNotification) {
        return '';
    }

    return $fallbackTranslation;
});
```

Feels like a lot of code to disable fallback language.