### PR TITLE
Add macro for `$this->translations()` in factories

### DIFF
--- a/docs/advanced-usage/usage-with-factories.md
+++ b/docs/advanced-usage/usage-with-factories.md
@@ -1,0 +1,41 @@
+---
+title: Usage with factories
+weight: 1
+---
+
+A small helper for making translations has been added for use in factories:
+
+This is what a few possible usages look like:
+
+```php
+/** @var $this \Illuminate\Database\Eloquent\Factories\Factory */
+
+$this->translatable('en', 'english')
+// output: ['en' => 'english']
+
+$this->translatable(['en', 'nl'], 'english')
+// output: ['en' => 'english', 'nl' => 'english']
+
+$this->translatable(['en', 'nl'], ['english', 'dutch'])
+// output: ['en' => 'english', 'nl' => 'dutch']
+```
+
+The helper can also be used outside of factories using the following syntax:
+
+```php
+\Illuminate\Database\Eloquent\Factories\Factory::translatable('en', 'english');
+// output: ['en' => 'english']
+```
+
+## In a Factory 
+
+```php
+class UserFactory extends \Illuminate\Database\Eloquent\Factories\Factory {
+    public function definition(): array
+    {
+        return [
+            'bio' => $this->translatable('en', 'english'),
+        ];
+    }
+}
+```

--- a/docs/advanced-usage/usage-with-factories.md
+++ b/docs/advanced-usage/usage-with-factories.md
@@ -10,20 +10,20 @@ This is what a few possible usages look like:
 ```php
 /** @var $this \Illuminate\Database\Eloquent\Factories\Factory */
 
-$this->translatable('en', 'english')
+$this->translations('en', 'english')
 // output: ['en' => 'english']
 
-$this->translatable(['en', 'nl'], 'english')
+$this->translations(['en', 'nl'], 'english')
 // output: ['en' => 'english', 'nl' => 'english']
 
-$this->translatable(['en', 'nl'], ['english', 'dutch'])
+$this->translations(['en', 'nl'], ['english', 'dutch'])
 // output: ['en' => 'english', 'nl' => 'dutch']
 ```
 
 The helper can also be used outside of factories using the following syntax:
 
 ```php
-\Illuminate\Database\Eloquent\Factories\Factory::translatable('en', 'english');
+\Illuminate\Database\Eloquent\Factories\Factory::translations('en', 'english');
 // output: ['en' => 'english']
 ```
 
@@ -34,7 +34,7 @@ class UserFactory extends \Illuminate\Database\Eloquent\Factories\Factory {
     public function definition(): array
     {
         return [
-            'bio' => $this->translatable('en', 'english'),
+            'bio' => $this->translations('en', 'english'),
         ];
     }
 }

--- a/src/TranslatableServiceProvider.php
+++ b/src/TranslatableServiceProvider.php
@@ -22,8 +22,8 @@ class TranslatableServiceProvider extends PackageServiceProvider
         Factory::macro('translatable', function (string|array $locales, mixed $value) {
             return json_encode(
                 is_array($value)
-                    ? array_combine((array)$locale, $value)
-                    : array_fill_keys((array)$locale, $value)
+                    ? array_combine((array)$locales, $value)
+                    : array_fill_keys((array)$locales, $value)
             );
         });
     }

--- a/src/TranslatableServiceProvider.php
+++ b/src/TranslatableServiceProvider.php
@@ -4,6 +4,7 @@ namespace Spatie\Translatable;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
 class TranslatableServiceProvider extends PackageServiceProvider
 {
@@ -17,5 +18,13 @@ class TranslatableServiceProvider extends PackageServiceProvider
     {
         $this->app->singleton(Translatable::class, fn () => new Translatable());
         $this->app->bind('translatable', Translatable::class);
+        
+        Factory::macro('translatable', function (string|array $locales, mixed $value) {
+            return json_encode(
+                is_array($value)
+                    ? array_combine((array)$locale, $value)
+                    : array_fill_keys((array)$locale, $value)
+            );
+        });
     }
 }

--- a/src/TranslatableServiceProvider.php
+++ b/src/TranslatableServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\Translatable;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Illuminate\Database\Eloquent\Factories\Factory;
 
 class TranslatableServiceProvider extends PackageServiceProvider
 {
@@ -18,13 +18,11 @@ class TranslatableServiceProvider extends PackageServiceProvider
     {
         $this->app->singleton(Translatable::class, fn () => new Translatable());
         $this->app->bind('translatable', Translatable::class);
-        
+
         Factory::macro('translatable', function (string|array $locales, mixed $value) {
-            return json_encode(
-                is_array($value)
-                    ? array_combine((array)$locales, $value)
-                    : array_fill_keys((array)$locales, $value)
-            );
+            return is_array($value)
+                ? array_combine((array)$locales, $value)
+                : array_fill_keys((array)$locales, $value);
         });
     }
 }

--- a/src/TranslatableServiceProvider.php
+++ b/src/TranslatableServiceProvider.php
@@ -19,7 +19,7 @@ class TranslatableServiceProvider extends PackageServiceProvider
         $this->app->singleton(Translatable::class, fn () => new Translatable());
         $this->app->bind('translatable', Translatable::class);
 
-        Factory::macro('translatable', function (string|array $locales, mixed $value) {
+        Factory::macro('translations', function (string|array $locales, mixed $value) {
             return is_array($value)
                 ? array_combine((array)$locales, $value)
                 : array_fill_keys((array)$locales, $value);

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 use Spatie\Translatable\Facades\Translatable;
@@ -760,3 +761,11 @@ it('can disable attribute locale fallback on a per model basis', function () {
 
     expect($model->name)->toBe('');
 });
+
+it('translatable macro meets expectations', function (mixed $expected, string|array $locales, mixed $value) {
+    expect(Factory::translatable($locales, $value))->toEqual($expected);
+})->with([
+    [['en' => 'english'], 'en', 'english'],
+    [['en' => 'english', 'nl' => 'english'], ['en', 'nl'], 'english'],
+    [['en' => 'english', 'nl' => 'dutch'], ['en', 'nl'], ['english', 'dutch']],
+]);

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -762,8 +762,8 @@ it('can disable attribute locale fallback on a per model basis', function () {
     expect($model->name)->toBe('');
 });
 
-it('translatable macro meets expectations', function (mixed $expected, string|array $locales, mixed $value) {
-    expect(Factory::translatable($locales, $value))->toEqual($expected);
+it('translations macro meets expectations', function (mixed $expected, string|array $locales, mixed $value) {
+    expect(Factory::translations($locales, $value))->toEqual($expected);
 })->with([
     [['en' => 'english'], 'en', 'english'],
     [['en' => 'english', 'nl' => 'english'], ['en', 'nl'], 'english'],


### PR DESCRIPTION
### Context

Because factory definitions do not go through a Model's accessors/mutators, old definitions break when migrating columns to use the translatable trait. This PR helps users overcome this hurdle, by adding a macro to the factory that outputs valid JSON for the translatable columns.

### Proposal

This macro enables users to do the following in factory definitions, where `description` is a translatable column:

**Scenario 1:**
```php
return [
  'description' => $this->translatable('en', 'English description'),
];

// output: {"en":"English description"}
```

**Scenario 2:**

```php
return [
  'description' => $this->translatable(['en', 'nl'], 'English and Dutch description'),
];

// output: {"en":"English and Dutch description","nl":"English and Dutch description"}
```

**Scenario 3:**

```php
return [
  'description' => $this->translatable(
    ['en', 'nl'],
    [
      'English description',
      'Dutch description',
    ]
  ),
];

// output: "{"en":"English description","nl":"Dutch description"}"
```

The `translatable` function can also be used statically, using `Factory::translatable`

### Documentation

I would appreciate some guidance on the documentation, specifically what page this should be documented on.