### PR TITLE
update customize-the-toarray-method.md

### DIFF
--- a/docs/advanced-usage/customize-the-toarray-method.md
+++ b/docs/advanced-usage/customize-the-toarray-method.md
@@ -17,11 +17,15 @@ trait HasTranslations
 
     public function toArray()
     {
-        $attributes = parent::toArray();
-        foreach ($this->getTranslatableAttributes() as $field) {
+        $attributes = $this->attributesToArray(); // attributes selected by the query
+        // remove attributes if they are not selected
+        $translatables = array_filter($this->getTranslatableAttributes(), function ($key) use ($attributes) {
+            return array_key_exists($key, $attributes);
+        });
+        foreach ($translatables as $field) {
             $attributes[$field] = $this->getTranslation($field, \App::getLocale());
         }
-        return $attributes;
+        return array_merge($attributes, $this->relationsToArray());
     }
 }
 ```


### PR DESCRIPTION
The current example doesn't respect the selected columns by the query builder and returns unselected attributes as empty string if they are translatable This new function will account for this issue