### PR TITLE
Add getFallbackLocale method

### DIFF
--- a/docs/basic-usage/handling-missing-translations.md
+++ b/docs/basic-usage/handling-missing-translations.md
@@ -33,6 +33,29 @@ as `$fallbackLocale` parameter:
     );
 ```
 
+### Fallback locale per model
+
+If the fallback locale differs between models, you can define a `getFallbackLocale()` method on your model.
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\HasTranslations;
+
+class NewsItem extends Model
+{
+    use HasTranslations;
+
+    public $fillable = ['name', 'fallback_locale'];
+
+    public $translatable = ['name'];
+
+    public function getFallbackLocale() : string
+    {
+        return $this->fallback_locale;
+    }
+}
+```
+
 ### Falling back to any locale
 
 Sometimes it is favored to return any translation if neither the translation for the preferred locale nor the fallback

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -241,9 +241,13 @@ trait HasTranslations
             return $locale;
         }
 
+        if (method_exists($this, 'getFallbackLocale')) {
+            $fallbackLocale = $this->getFallbackLocale();
+        }
+
         $fallbackConfig = app(Translatable::class);
 
-        $fallbackLocale = $fallbackConfig->fallbackLocale ?? config('app.fallback_locale');
+        $fallbackLocale ??= $fallbackConfig->fallbackLocale ?? config('app.fallback_locale');
 
         if (! is_null($fallbackLocale) && in_array($fallbackLocale, $translatedLocales)) {
             return $fallbackLocale;

--- a/tests/TestSupport/TestModelWithFallbackLocale.php
+++ b/tests/TestSupport/TestModelWithFallbackLocale.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\Translatable\Test\TestSupport;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\HasTranslations;
+
+class TestModelWithFallbackLocale extends Model
+{
+    use HasTranslations;
+
+    public static $fallbackLocale;
+
+    protected $table = 'test_models';
+
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public $translatable = ['name', 'other_field', 'field_with_mutator'];
+
+    public function getFallbackLocale() : string
+    {
+        return static::$fallbackLocale;
+    }
+
+    public function setFieldWithMutatorAttribute($value)
+    {
+        $this->attributes['field_with_mutator'] = $value;
+    }
+}

--- a/tests/TestSupport/TestModelWithFallbackLocale.php
+++ b/tests/TestSupport/TestModelWithFallbackLocale.php
@@ -18,7 +18,7 @@ class TestModelWithFallbackLocale extends Model
 
     public $translatable = ['name', 'other_field', 'field_with_mutator'];
 
-    public function getFallbackLocale() : string
+    public function getFallbackLocale(): string
     {
         return static::$fallbackLocale;
     }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Storage;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 use Spatie\Translatable\Facades\Translatable;
 use Spatie\Translatable\Test\TestSupport\TestModel;
+use Spatie\Translatable\Test\TestSupport\TestModelWithFallbackLocale;
 use Spatie\Translatable\Test\TestSupport\TestModelWithoutFallback;
 
 beforeEach(function () {
@@ -760,6 +761,22 @@ it('can disable attribute locale fallback on a per model basis', function () {
     $model->setLocale('fr');
 
     expect($model->name)->toBe('');
+});
+
+it('can set fallback locale on model', function () {
+    config()->set('app.fallback_locale', 'en');
+
+    $model = new TestModelWithFallbackLocale();
+
+    TestModelWithFallbackLocale::$fallbackLocale = 'fr';
+
+    $model->setTranslation('name', 'fr', 'testValue_fr');
+    $model->setTranslation('name', 'en', 'testValue_en');
+    $model->save();
+
+    $model->setLocale('nl');
+
+    expect($model->name)->toBe('testValue_fr');
 });
 
 it('translations macro meets expectations', function (mixed $expected, string|array $locales, mixed $value) {


### PR DESCRIPTION
In a project I'm working on, my models have translatable attributes but also a 'fallback_locale' attribute. If for example the title of the model does not have a translation in the user's current locale, then it should use the translation in the 'fallback_locale' that is set on the model (instead of a global fallback locale that is set for entire application). To support this behavior, this PR adds the option to define a `getFallbackLocale` method on a model

```php
class Article extends Model
{
    use HasTranslations;

	protected $translatable = [
       'title',
    ];

    public function getFallbackLocale() : string
    {
        return $this->fallback_locale; // a column/attribute on the model
    }
}
```

```php
$article->setTranslation('title', 'fr', 'french title');
$article->setTranslation('title', 'en', 'english title');
$article->forceFill(['fallback_locale' => 'fr']);

config()->set('app.fallback_locale', 'en');

app()->setLocale('nl');

// The french translation is returned because no dutch translation exist
dump($article->title);
```
