### PR TITLE
Convert static methods to scopes

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -328,14 +328,14 @@ trait HasTranslations
         );
     }
 
-    public static function whereLocale(string $column, string $locale): Builder
+    public function scopeWhereLocale(Builder $query, string $column, string $locale): void
     {
-        return static::query()->whereNotNull("{$column}->{$locale}");
+        $query->whereNotNull("{$column}->{$locale}");
     }
 
-    public static function whereLocales(string $column, array $locales): Builder
+    public function scopeWhereLocales(Builder $query, string $column, array $locales): void
     {
-        return static::query()->where(function (Builder $query) use ($column, $locales) {
+        $query->where(function (Builder $query) use ($column, $locales) {
             foreach ($locales as $locale) {
                 $query->orWhereNotNull("{$column}->{$locale}");
             }

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -341,4 +341,24 @@ trait HasTranslations
             }
         });
     }
+
+    /**
+     * @deprecated
+     */
+    public static function whereLocale(string $column, string $locale): Builder
+    {
+        return static::query()->whereNotNull("{$column}->{$locale}");
+    }
+
+    /**
+     * @deprecated
+     */
+    public static function whereLocales(string $column, array $locales): Builder
+    {
+        return static::query()->where(function (Builder $query) use ($column, $locales) {
+            foreach ($locales as $locale) {
+                $query->orWhereNotNull("{$column}->{$locale}");
+            }
+        });
+    }
 }


### PR DESCRIPTION
Converting the `whereLocale()` / `whereLocales()` static methods to scopes makes it possible to use them on existing queries instead of being required to use them as the first method