### PR TITLE
Keep the number of translations even with null values

### DIFF
--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -39,7 +39,7 @@ it('provides a flog to not return fallback locale translation when getting an un
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    expect($this->testModel->getTranslation('name', 'fr', false))->toBe('');
+    expect($this->testModel->getTranslation('name', 'fr', false))->toBe(null);
 });
 
 it('will return fallback locale translation when getting an unknown locale and fallback is true', function () {
@@ -126,7 +126,7 @@ it('will return an empty string when getting an unknown locale and fallback is n
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    expect($this->testModel->getTranslationWithoutFallback('name', 'fr'))->toBe('');
+    expect($this->testModel->getTranslationWithoutFallback('name', 'fr'))->toBe(null);
 });
 
 it('will return an empty string when getting an unknown locale and fallback is empty', function () {
@@ -139,7 +139,7 @@ it('will return an empty string when getting an unknown locale and fallback is e
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    expect($this->testModel->getTranslation('name', 'fr'))->toBe('');
+    expect($this->testModel->getTranslation('name', 'fr'))->toBe(null);
 });
 
 it('can save a translated attribute', function () {
@@ -147,6 +147,13 @@ it('can save a translated attribute', function () {
     $this->testModel->save();
 
     expect($this->testModel->name)->toBe('testValue_en');
+});
+
+it('can save null value in a translated attribute', function () {
+    $this->testModel->setTranslation('name', 'en', null);
+    $this->testModel->save();
+
+    expect($this->testModel->name)->toBe(null);
 });
 
 it('can set translated values when creating a model', function () {
@@ -448,11 +455,21 @@ it('can check if an attribute is translatable', function () {
 it('can check if an attribute has translation', function () {
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->setTranslation('name', 'nl', null);
+    $this->testModel->setTranslation('name', 'de', null);
     $this->testModel->save();
 
     expect($this->testModel->hasTranslation('name', 'en'))->toBeTrue();
 
     expect($this->testModel->hasTranslation('name', 'pt'))->toBeFalse();
+});
+
+it('will return the same number of translations with the same values as saved', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'nl', null);
+    $this->testModel->setTranslation('name', 'de', '');
+    $this->testModel->save();
+
+    expect($this->testModel->getTranslations('name'))->toEqual(['en' => 'testValue_en', 'nl' => null, 'de' => '']);
 });
 
 it('can correctly set a field when a mutator is defined', function () {
@@ -699,7 +716,7 @@ it('provides a flog to not return any translation when getting an unknown locale
     $this->testModel->save();
 
     $this->testModel->setLocale('it');
-    expect($this->testModel->getTranslation('name', 'it', false))->toBe('');
+    expect($this->testModel->getTranslation('name', 'it', false))->toBe(null);
 });
 
 it('will return default fallback locale translation when getting an unknown locale with fallback any', function () {
@@ -760,7 +777,7 @@ it('can disable attribute locale fallback on a per model basis', function () {
 
     $model->setLocale('fr');
 
-    expect($model->name)->toBe('');
+    expect($model->name)->toBe(null);
 });
 
 it('can set fallback locale on model', function () {


### PR DESCRIPTION
Currently, when saving this in the model:

```php
['en' => 'Title', 'nl' => null, 'de' => null]
```

…we have this in database:

```php
['en': 'Title', 'de': null]
```

This pull request fix this strange behavior and the data saved in the database is now:

```php
['en' => 'Title', 'nl' => null, 'de' => null]
```

Note : In the version 3.1.3 of this package, the number of translations where correctly maintained in the database, I don't know exactly when this behavior changed, but it can lead to bugs in some situations.