### PR TITLE
Revert "Keep null value"

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -65,7 +65,7 @@ trait HasTranslations
 
         $translations = $this->getTranslations($key);
 
-        $translation = $translations[$normalizedLocale] ?? null;
+        $translation = $translations[$normalizedLocale] ?? '';
 
         $translatableConfig = app(Translatable::class);
 
@@ -101,20 +101,20 @@ trait HasTranslations
         return $this->getTranslation($key, $locale, false);
     }
 
-    public function getTranslations(string $key = null, array $allowedLocales = null, bool $keepNullValues = true): array
+    public function getTranslations(string $key = null, array $allowedLocales = null): array
     {
         if ($key !== null) {
             $this->guardAgainstNonTranslatableAttribute($key);
 
             return array_filter(
                 json_decode($this->getAttributes()[$key] ?? '' ?: '{}', true) ?: [],
-                fn ($value, $locale) => $this->filterTranslations($value, $locale, $allowedLocales, $keepNullValues),
+                fn ($value, $locale) => $this->filterTranslations($value, $locale, $allowedLocales),
                 ARRAY_FILTER_USE_BOTH,
             );
         }
 
-        return array_reduce($this->getTranslatableAttributes(), function ($result, $item) use ($allowedLocales, $keepNullValues) {
-            $result[$item] = $this->getTranslations($item, $allowedLocales, $keepNullValues);
+        return array_reduce($this->getTranslatableAttributes(), function ($result, $item) use ($allowedLocales) {
+            $result[$item] = $this->getTranslations($item, $allowedLocales);
 
             return $result;
         });
@@ -204,7 +204,7 @@ trait HasTranslations
 
     public function getTranslatedLocales(string $key): array
     {
-        return array_keys($this->getTranslations($key, null, false));
+        return array_keys($this->getTranslations($key));
     }
 
     public function isTranslatableAttribute(string $key): bool
@@ -268,16 +268,14 @@ trait HasTranslations
         return $locale;
     }
 
-    protected function filterTranslations(mixed $value = null, string $locale = null, array $allowedLocales = null, bool $keepNullValues = true): bool
+    protected function filterTranslations(mixed $value = null, string $locale = null, array $allowedLocales = null): bool
     {
-        if (! $keepNullValues) {
-            if ($value === null) {
-                return false;
-            }
+        if ($value === null) {
+            return false;
+        }
 
-            if ($value === '') {
-                return false;
-            }
+        if ($value === '') {
+            return false;
         }
 
         if ($allowedLocales === null) {

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -39,7 +39,7 @@ it('provides a flog to not return fallback locale translation when getting an un
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    expect($this->testModel->getTranslation('name', 'fr', false))->toBe(null);
+    expect($this->testModel->getTranslation('name', 'fr', false))->toBe('');
 });
 
 it('will return fallback locale translation when getting an unknown locale and fallback is true', function () {
@@ -126,7 +126,7 @@ it('will return an empty string when getting an unknown locale and fallback is n
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    expect($this->testModel->getTranslationWithoutFallback('name', 'fr'))->toBe(null);
+    expect($this->testModel->getTranslationWithoutFallback('name', 'fr'))->toBe('');
 });
 
 it('will return an empty string when getting an unknown locale and fallback is empty', function () {
@@ -139,7 +139,7 @@ it('will return an empty string when getting an unknown locale and fallback is e
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->save();
 
-    expect($this->testModel->getTranslation('name', 'fr'))->toBe(null);
+    expect($this->testModel->getTranslation('name', 'fr'))->toBe('');
 });
 
 it('can save a translated attribute', function () {
@@ -147,13 +147,6 @@ it('can save a translated attribute', function () {
     $this->testModel->save();
 
     expect($this->testModel->name)->toBe('testValue_en');
-});
-
-it('can save null value in a translated attribute', function () {
-    $this->testModel->setTranslation('name', 'en', null);
-    $this->testModel->save();
-
-    expect($this->testModel->name)->toBe(null);
 });
 
 it('can set translated values when creating a model', function () {
@@ -455,21 +448,11 @@ it('can check if an attribute is translatable', function () {
 it('can check if an attribute has translation', function () {
     $this->testModel->setTranslation('name', 'en', 'testValue_en');
     $this->testModel->setTranslation('name', 'nl', null);
-    $this->testModel->setTranslation('name', 'de', null);
     $this->testModel->save();
 
     expect($this->testModel->hasTranslation('name', 'en'))->toBeTrue();
 
     expect($this->testModel->hasTranslation('name', 'pt'))->toBeFalse();
-});
-
-it('will return the same number of translations with the same values as saved', function () {
-    $this->testModel->setTranslation('name', 'en', 'testValue_en');
-    $this->testModel->setTranslation('name', 'nl', null);
-    $this->testModel->setTranslation('name', 'de', '');
-    $this->testModel->save();
-
-    expect($this->testModel->getTranslations('name'))->toEqual(['en' => 'testValue_en', 'nl' => null, 'de' => '']);
 });
 
 it('can correctly set a field when a mutator is defined', function () {
@@ -716,7 +699,7 @@ it('provides a flog to not return any translation when getting an unknown locale
     $this->testModel->save();
 
     $this->testModel->setLocale('it');
-    expect($this->testModel->getTranslation('name', 'it', false))->toBe(null);
+    expect($this->testModel->getTranslation('name', 'it', false))->toBe('');
 });
 
 it('will return default fallback locale translation when getting an unknown locale with fallback any', function () {
@@ -777,7 +760,7 @@ it('can disable attribute locale fallback on a per model basis', function () {
 
     $model->setLocale('fr');
 
-    expect($model->name)->toBe(null);
+    expect($model->name)->toBe('');
 });
 
 it('can set fallback locale on model', function () {


### PR DESCRIPTION
Hi 👋

This PR reverts the changes made in the original PR. Even though I am a proponent of the suggested changes, unfortunately it's a breaking change for people who don't make use of type juggling through the use of `declare(strict_types=1)`. 
Moreover, this is also going to break the code of those who are on the most recent PHP versions where `str_*` functions no longer accept `null` as a legitimate value.

The suggested changes should be targeted at a `v7` or a `next` branch, ideally.

Thank you 🙏