### PR TITLE
fix: allow raw searchable umlauts

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -137,12 +137,12 @@ trait HasTranslations
         } elseif($this->hasAttributeSetMutator($key)) { // handle new attribute mutator
             $this->setAttributeMarkedMutatedAttributeValue($key, $value);
 
-            $this->attributes[$key] = json_encode($translations, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $value = $this->attributes[$key];
         }
 
         $translations[$locale] = $value;
 
-        $this->attributes[$key] = $this->asJson($translations);
+        $this->attributes[$key] = json_encode($translations, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         event(new TranslationHasBeenSetEvent($this, $key, $locale, $oldValue, $value));
 

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -137,7 +137,7 @@ trait HasTranslations
         } elseif($this->hasAttributeSetMutator($key)) { // handle new attribute mutator
             $this->setAttributeMarkedMutatedAttributeValue($key, $value);
 
-            $value = $this->attributes[$key];
+            $this->attributes[$key] = json_encode($translations, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
         }
 
         $translations[$locale] = $value;


### PR DESCRIPTION
German Umlauts are not searchable with `whereRaw` with escaped unicodes.