### PR TITLE
fix: allow raw searchable umlauts

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -142,7 +142,7 @@ trait HasTranslations
 
         $translations[$locale] = $value;
 
-        $this->attributes[$key] = $this->asJson($translations);
+        $this->attributes[$key] = json_encode($translations, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         event(new TranslationHasBeenSetEvent($this, $key, $locale, $oldValue, $value));
 


### PR DESCRIPTION
German umlauts were not searchable with `whereRaw` and escaped unicodes in the JSON.