### PR TITLE
Fix toArray when using accessors on translatable attributes

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -36,6 +36,17 @@ trait HasTranslations
         return $this->getTranslation($key, $this->getLocale(), $this->useFallbackLocale());
     }
 
+    protected function mutateAttributeForArray($key, $value): mixed
+    {
+        if (! $this->isTranslatableAttribute($key)) {
+            return parent::mutateAttributeForArray($key, $value);
+        }
+
+        $translations = $this->getTranslations($key);
+
+        return array_map(fn ($value) => parent::mutateAttributeForArray($key, $value), $translations);
+    }
+
     public function setAttribute($key, $value)
     {
         if ($this->isTranslatableAttribute($key) && is_array($value)) {

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -397,6 +397,25 @@ it('can use accessors on translated attributes', function () {
     expect('I just accessed testValue_en')->toEqual($testModel->name);
 });
 
+it('can be converted to array when using accessors on translated attributes', function () {
+    $testModel = new class () extends TestModel {
+        public function getNameAttribute($value)
+        {
+            return "I just accessed {$value}";
+        }
+    };
+
+    $testModel->setTranslation('name', 'en', 'testValue_en');
+    $testModel->setTranslation('name', 'nl', 'testValue_nl');
+
+    expect($testModel->toArray())
+        ->toHaveKey('name')
+        ->toContain([
+            'en' => 'I just accessed testValue_en',
+            'nl' => 'I just accessed testValue_nl',
+        ]);
+});
+
 it('can use mutators on translated attributes', function () {
     $testModel = new class () extends TestModel {
         public function setNameAttribute($value)


### PR DESCRIPTION
Hi,

When using accessors on translatable attributes, the `toArray` method doesn't work like expected.
Normally when you get the value of an attribute, the accessor gets the translated value as its parameter. When using `toArray` on the model the accessor gets the raw value instead.
I've added a test to reproduce the issue.

This change only affects translated attributes with accessors, the `mutateAttributeForArray` method gets called only for attributes with accessors defined.