### PR TITLE
[FEAT] add ability for filtering a column's locale or multiple locale…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ $newsItem->name; // Returns 'Naam in het Nederlands'
 NewsItem::whereLocale('name', 'en')->get(); // Returns all news items with a name in English
 
 NewsItem::whereLocales('name', ['en', 'nl'])->get(); // Returns all news items with a name in English or Dutch
+
+// Returns all news items that has name in English with value `Name in English` 
+NewsItem::query()->whereJsonContainsLocale('name', 'en', 'Name in English')->get(); 
+
+// Returns all news items that has name in English or Dutch with value `Name in English` 
+NewsItem::query()->whereJsonContainsLocales('name', ['en', 'nl'], 'Name in English')->get(); 
+
+
 ```
 
 ## Support us

--- a/docs/basic-usage/querying-translations.md
+++ b/docs/basic-usage/querying-translations.md
@@ -22,3 +22,13 @@ NewsItem::whereLocale('name', 'en')->get(); // Returns all news items with a nam
 
 NewsItem::whereLocales('name', ['en', 'nl'])->get(); // Returns all news items with a name in English or Dutch
 ```
+
+If you want to query records based on locale's value, you can use the `whereJsonContainsLocale` and `whereJsonContainsLocales` methods.
+
+```php
+// Returns all news items that has name in English with value `Name in English` 
+NewsItem::query()->whereJsonContainsLocale('name', 'en', 'Name in English')->get(); 
+
+// Returns all news items that has name in English or Dutch with value `Name in English` 
+NewsItem::query()->whereJsonContainsLocales('name', ['en', 'nl'], 'Name in English')->get(); 
+```

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -361,6 +361,20 @@ trait HasTranslations
         });
     }
 
+    public function scopeWhereJsonContainsLocale(Builder $query, string $column, string $locale, mixed $value): void
+    {
+        $query->whereJsonContains("{$column}->{$locale}", $value);
+    }
+
+    public function scopeWhereJsonContainsLocales(Builder $query, string $column, array $locales, mixed $value): void
+    {
+        $query->where(function (Builder $query) use ($column, $locales, $value) {
+            foreach($locales as $locale) {
+                $query->orWhereJsonContains("{$column}->{$locale}", $value);
+            }
+        });
+    }
+
     /**
      * @deprecated
      */

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -363,14 +363,14 @@ trait HasTranslations
 
     public function scopeWhereJsonContainsLocale(Builder $query, string $column, string $locale, mixed $value): void
     {
-        $query->whereJsonContains("{$column}->{$locale}", $value);
+        $query->where("{$column}->{$locale}", $value);
     }
 
     public function scopeWhereJsonContainsLocales(Builder $query, string $column, array $locales, mixed $value): void
     {
         $query->where(function (Builder $query) use ($column, $locales, $value) {
             foreach($locales as $locale) {
-                $query->orWhereJsonContains("{$column}->{$locale}", $value);
+                $query->orWhere("{$column}->{$locale}", $value);
             }
         });
     }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -769,6 +769,28 @@ it('queries the database for multiple locales', function () {
     expect($this->testModel->whereLocales('name', ['de', 'be'])->get())->toHaveCount(0);
 });
 
+it('queries the database whether a value exists in a locale', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->setTranslation('name', 'tr', 'testValue_tr');
+    $this->testModel->save();
+
+    expect($this->testModel->whereJsonContainsLocale('name', 'en', 'testValue_en')->get())->toHaveCount(1);
+
+    expect($this->testModel->whereJsonContainsLocale('name', 'en', 'testValue_fr')->get())->toHaveCount(0);
+});
+
+it('queries the database whether a value exists in a multiple locales', function () {
+    $this->testModel->setTranslation('name', 'en', 'testValue_en');
+    $this->testModel->setTranslation('name', 'fr', 'testValue_fr');
+    $this->testModel->setTranslation('name', 'tr', 'testValue_tr');
+    $this->testModel->save();
+
+    expect($this->testModel->whereJsonContainsLocales('name', ['en', 'fr'], 'testValue_en')->get())->toHaveCount(1);
+
+    expect($this->testModel->whereJsonContainsLocales('name', ['en', 'fr'], 'testValue_tr')->get())->toHaveCount(0);
+});
+
 it('can disable attribute locale fallback on a per model basis', function () {
     config()->set('app.fallback_locale', 'en');
 


### PR DESCRIPTION
Add ability for filter a translatable json column with a value depending on it's locale or multiple locales 
for example:
```
// Returns all news items that has name in English with value `Name in English` 
NewsItem::query()->whereJsonContainsLocale('name', 'en', 'Name in English')->get(); 

// Returns all news items that has name in English or Dutch with value `Name in English` 
NewsItem::query()->whereJsonContainsLocales('name', ['en', 'nl'], 'Name in English')->get();
```
