### PR TITLE
fix: PHPDoc block in Translatable facade

### DIFF
--- a/src/Facades/Translatable.php
+++ b/src/Facades/Translatable.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @see \Spatie\Translatable\Translatable
  *
- * @method static fallback(?string $fallbackLocale = null, ?bool $fallbackAny = false, $missingKeyCallback = null)
+ * @method static void fallback(?string $fallbackLocale = null, ?bool $fallbackAny = false, $missingKeyCallback = null)
  */
 class Translatable extends Facade
 {


### PR DESCRIPTION
Fix fallback method definition that is lacking "void", occasioning code analyzers like PHPStan to fail. This was recently introduced [here](https://github.com/spatie/laravel-translatable/pull/438).

The previous PHPdoc is not a valid php-doc comment and causes issues on, for example, PHPStan when analyzing the code:

![image](https://github.com/spatie/laravel-translatable/assets/24867662/9c4c6751-9c88-44f8-b525-1fe4a2f37646)
