### PR TITLE
Added operand for json scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,16 @@ NewsItem::whereLocale('name', 'en')->get(); // Returns all news items with a nam
 NewsItem::whereLocales('name', ['en', 'nl'])->get(); // Returns all news items with a name in English or Dutch
 
 // Returns all news items that has name in English with value `Name in English` 
-NewsItem::query()->whereJsonContainsLocale('name', 'en', 'Name in English')->get(); 
+NewsItem::query()->whereJsonContainsLocale('name', 'en', 'Name in English')->get();
+
+// Returns all news items that has name in English with value like `Name in...` 
+NewsItem::query()->whereJsonContainsLocale('name', 'en', 'Name in%', 'like')->get();
 
 // Returns all news items that has name in English or Dutch with value `Name in English` 
-NewsItem::query()->whereJsonContainsLocales('name', ['en', 'nl'], 'Name in English')->get(); 
+NewsItem::query()->whereJsonContainsLocales('name', ['en', 'nl'], 'Name in English')->get();
+
+// Returns all news items that has name in English or Dutch with value like `Name in...` 
+NewsItem::query()->whereJsonContainsLocales('name', ['en', 'nl'], 'Name in%', 'like')->get();
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ NewsItem::whereLocales('name', ['en', 'nl'])->get(); // Returns all news items w
 // Returns all news items that has name in English with value `Name in English` 
 NewsItem::query()->whereJsonContainsLocale('name', 'en', 'Name in English')->get();
 
-// Returns all news items that has name in English with value like `Name in...` 
-NewsItem::query()->whereJsonContainsLocale('name', 'en', 'Name in%', 'like')->get();
-
 // Returns all news items that has name in English or Dutch with value `Name in English` 
 NewsItem::query()->whereJsonContainsLocales('name', ['en', 'nl'], 'Name in English')->get();
+
+// The last argument is the "operand" which you can tweak to achieve something like this:
+
+// Returns all news items that has name in English with value like `Name in...` 
+NewsItem::query()->whereJsonContainsLocale('name', 'en', 'Name in%', 'like')->get();
 
 // Returns all news items that has name in English or Dutch with value like `Name in...` 
 NewsItem::query()->whereJsonContainsLocales('name', ['en', 'nl'], 'Name in%', 'like')->get();

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -361,16 +361,16 @@ trait HasTranslations
         });
     }
 
-    public function scopeWhereJsonContainsLocale(Builder $query, string $column, string $locale, mixed $value): void
+    public function scopeWhereJsonContainsLocale(Builder $query, string $column, string $locale, mixed $value, string $operand = '='): void
     {
-        $query->where("{$column}->{$locale}", $value);
+        $query->where("{$column}->{$locale}", $operand, $value);
     }
 
-    public function scopeWhereJsonContainsLocales(Builder $query, string $column, array $locales, mixed $value): void
+    public function scopeWhereJsonContainsLocales(Builder $query, string $column, array $locales, mixed $value, string $operand = '='): void
     {
-        $query->where(function (Builder $query) use ($column, $locales, $value) {
+        $query->where(function (Builder $query) use ($column, $locales, $value, $operand) {
             foreach($locales as $locale) {
-                $query->orWhere("{$column}->{$locale}", $value);
+                $query->orWhere("{$column}->{$locale}", $operand, $value);
             }
         });
     }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -777,6 +777,8 @@ it('queries the database whether a value exists in a locale', function () {
 
     expect($this->testModel->whereJsonContainsLocale('name', 'en', 'testValue_en')->get())->toHaveCount(1);
 
+    expect($this->testModel->whereJsonContainsLocale('name', 'en', 'test%en', 'like')->get())->toHaveCount(1);
+
     expect($this->testModel->whereJsonContainsLocale('name', 'en', 'testValue_fr')->get())->toHaveCount(0);
 });
 
@@ -787,6 +789,8 @@ it('queries the database whether a value exists in a multiple locales', function
     $this->testModel->save();
 
     expect($this->testModel->whereJsonContainsLocales('name', ['en', 'fr'], 'testValue_en')->get())->toHaveCount(1);
+
+    expect($this->testModel->whereJsonContainsLocales('name', ['en', 'fr'], 'test%en', 'like')->get())->toHaveCount(1);
 
     expect($this->testModel->whereJsonContainsLocales('name', ['en', 'fr'], 'testValue_tr')->get())->toHaveCount(0);
 });


### PR DESCRIPTION
Hi,

I've added ability to choose operand for where clause in json scopes. For example:
```php
$query->whereJsonContainsLocale('title', 'en', 'hello%', 'like');
```