### PR TITLE
PHP 8.4 deprecates implicitly nullable parameter types.

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -112,7 +112,7 @@ trait HasTranslations
         return $this->getTranslation($key, $locale, false);
     }
 
-    public function getTranslations(string $key = null, array $allowedLocales = null): array
+    public function getTranslations(?string $key = null, ?array $allowedLocales = null): array
     {
         if ($key !== null) {
             $this->guardAgainstNonTranslatableAttribute($key);
@@ -223,7 +223,7 @@ trait HasTranslations
         return in_array($key, $this->getTranslatableAttributes());
     }
 
-    public function hasTranslation(string $key, string $locale = null): bool
+    public function hasTranslation(string $key, ?string $locale = null): bool
     {
         $locale = $locale ?: $this->getLocale();
 
@@ -279,7 +279,7 @@ trait HasTranslations
         return $locale;
     }
 
-    protected function filterTranslations(mixed $value = null, string $locale = null, array $allowedLocales = null): bool
+    protected function filterTranslations(mixed $value = null, ?string $locale = null, ?array $allowedLocales = null): bool
     {
         if ($value === null) {
             return false;

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -22,7 +22,7 @@ class Translatable
     public function fallback(
         ?string $fallbackLocale = null,
         ?bool $fallbackAny = false,
-        $missingKeyCallback = null
+        ?Closure $missingKeyCallback = null
     ): self {
         $this->fallbackLocale = $fallbackLocale;
         $this->fallbackAny = $fallbackAny;


### PR DESCRIPTION
This commit fixes the issue by adding nullable types to the method signatures. https://github.com/php/php-src/blob/php-8.4.0RC1/UPGRADING#L497

4. Deprecated Functionality

- Core: . Implicitly nullable parameter types are now deprecated. RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types