### PR TITLE
feat: create a command to list missing translations for a model

### DIFF
--- a/src/Commands/ListMissingTranslationsCommand.php
+++ b/src/Commands/ListMissingTranslationsCommand.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Spatie\Translatable\Commands;
+
+use InvalidArgumentException;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+
+class ListMissingTranslationsCommand extends Command
+{
+    protected $signature = 'translatable:missing
+                                {model : The model class to check (e.g., "User" or "App\\Models\\User")}
+                                {--locales= : Comma-separated list of locales to check}
+                                {--attributes= : Comma-separated list of attributes to check}';
+
+    protected $description = 'List missing translations for a specific translatable model';
+
+    public function handle(): void
+    {
+        $modelInput = $this->argument('model');
+
+        $modelClass = $this->resolveModelClass($modelInput);
+
+        if (!class_exists($modelClass)) {
+            throw new InvalidArgumentException("Model class {$modelClass} does not exist.");
+        }
+
+        $locales = $this->option('locales')
+            ? explode(',', $this->option('locales'))
+            : config('app.locales', [config('app.locale')]);
+
+        $model = new $modelClass;
+
+        if (!method_exists($model, 'getTranslatableAttributes')) {
+            throw new InvalidArgumentException(
+                "Model {$modelClass} does not use HasTranslations trait."
+            );
+        }
+
+        $attributes = $this->option('attributes')
+            ? explode(',', $this->option('attributes'))
+            : $model->getTranslatableAttributes();
+
+        $query = $modelClass::query();
+
+        $total = $query->count();
+
+        if ($total ==    0) {
+            throw new InvalidArgumentException(
+                "No records found for model $modelClass."
+            );
+        }
+
+        $this->info("Checking model: $modelClass");
+
+        $bar = $this->output->createProgressBar($total);
+
+        $bar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%');
+
+        $missingTranslations = collect();
+
+        $query->chunk(100, function ($models) use ($locales, $attributes, &$missingTranslations, $bar) {
+            foreach ($models as $model) {
+                foreach ($attributes as $attribute) {
+                    $missingLocales = $this->findMissingLocales($model, $attribute, $locales);
+
+                    if (!empty($missingLocales)) {
+                        $missingTranslations->push([
+                            'model' => get_class($model),
+                            'id' => $model->getKey(),
+                            'attribute' => $attribute,
+                            'missing_locales' => implode(', ', $missingLocales),
+                        ]);
+                    }
+                }
+                $bar->advance();
+            }
+        });
+
+        $bar->finish();
+
+        $this->line('');
+
+        if ($missingTranslations->isEmpty()) {
+            $this->info('All translations are complete for model!');
+            return;
+        }
+
+        $this->info('Missing Translations');
+
+        $this->table(
+            ['Model', 'ID', 'Attribute', 'Missing Locales'],
+            $missingTranslations
+        );
+
+        return;
+    }
+
+    private function findMissingLocales(Model $model, string $attribute, array $locales): array
+    {
+        return array_filter($locales, function ($locale) use ($model, $attribute) {
+            return !$model->hasTranslation($attribute, $locale);
+        });
+    }
+
+    private function resolveModelClass(string $modelInput): string
+    {
+        $possiblePaths = [
+            $modelInput,
+            "App\\Models\\$modelInput",
+            "App\\$modelInput"
+        ];
+
+        foreach ($possiblePaths as $path) {
+            if (class_exists($path)) {
+                return $path;
+            }
+        }
+
+        return $modelInput;
+    }
+}

--- a/src/Commands/ListMissingTranslationsCommand.php
+++ b/src/Commands/ListMissingTranslationsCommand.php
@@ -55,8 +55,6 @@ class ListMissingTranslationsCommand extends Command
 
         $bar = $this->output->createProgressBar($total);
 
-        $bar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%');
-
         $missingTranslations = collect();
 
         $query->chunk(100, function ($models) use ($locales, $attributes, &$missingTranslations, $bar) {

--- a/src/TranslatableServiceProvider.php
+++ b/src/TranslatableServiceProvider.php
@@ -5,6 +5,7 @@ namespace Spatie\Translatable;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\Translatable\Commands\ListMissingTranslationsCommand;
 
 class TranslatableServiceProvider extends PackageServiceProvider
 {
@@ -18,6 +19,12 @@ class TranslatableServiceProvider extends PackageServiceProvider
     {
         $this->app->singleton(Translatable::class, fn () => new Translatable());
         $this->app->bind('translatable', Translatable::class);
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                ListMissingTranslationsCommand::class,
+            ]);
+        }
 
         Factory::macro('translations', function (string|array $locales, mixed $value) {
             return is_array($value)

--- a/tests/ListMissingTranslationsCommandTest.php
+++ b/tests/ListMissingTranslationsCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Spatie\Translatable\Test;
+
+use Illuminate\Support\Facades\Artisan;
+use Spatie\Translatable\Test\TestSupport\TestModel;
+use InvalidArgumentException;
+
+beforeEach(function () {
+    $this->testModel = new TestModel();
+});
+
+it('lists missing translations', function () {
+    $model = $this->testModel::create([
+        'name' => [
+            'en' => 'Hello',
+            'fr' => '',
+            'es' => null,
+        ],
+    ]);
+
+    Artisan::call('translatable:missing', [
+        'model' => TestModel::class,
+        '--locales' => 'en,fr,es',
+        '--attributes' => 'name',
+    ]);
+
+    $output = Artisan::output();
+
+    expect($output)->toContain('Missing Translations');
+    expect($output)->toContain(TestModel::class);
+    expect($output)->toContain((string)$model->getKey());
+    expect($output)->toContain('name');
+    expect($output)->toContain('fr, es');
+    expect($output)->not->toContain('en');
+});
+
+it('reports all translations are complete when there are no missing translations', function () {
+    $model = $this->testModel::create([
+        'name' => [
+            'en' => 'Hello',
+            'fr' => 'Bonjour',
+            'es' => 'Hola',
+        ],
+    ]);
+
+    Artisan::call('translatable:missing', [
+        'model' => TestModel::class,
+        '--locales' => 'en,fr,es',
+        '--attributes' => 'name',
+    ]);
+
+    $output = Artisan::output();
+
+    expect($output)->toContain('All translations are complete for model');
+    expect($output)->toContain(TestModel::class);
+    expect($output)->not->toContain('Missing Translations');
+});
+
+it('reports when no records are found for the model', function () {
+    $this->testModel::truncate();
+
+    expect(fn () => Artisan::call('translatable:missing', [
+        'model' => TestModel::class,
+        '--locales' => 'en,fr,es',
+        '--attributes' => 'name',
+    ]))->toThrow(
+        InvalidArgumentException::class,
+        "No records found for model " . TestModel::class
+    );
+});
+


### PR DESCRIPTION
While working on an old project I often found missing translations. I wanted a quick way to check if a model has any attributes without translations. So I thought it would be helpful to have a feature that easily detects missing model translations.

![image](https://github.com/user-attachments/assets/74a1a182-f2f9-4904-b08d-415ac13e4d4e)
