### PR TITLE
Allow configuration for handling null and empty strings in translations (Fixes #456)

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -100,7 +100,7 @@ trait HasTranslations
             return $this->mutateAttribute($key, $translation);
         }
 
-        if($this->hasAttributeMutator($key)) {
+        if ($this->hasAttributeMutator($key)) {
             return $this->mutateAttributeMarkedAttribute($key, $translation);
         }
 
@@ -151,7 +151,7 @@ trait HasTranslations
             $this->{$method}($value, $locale);
 
             $value = $this->attributes[$key];
-        } elseif($this->hasAttributeSetMutator($key)) { // handle new attribute mutator
+        } elseif ($this->hasAttributeSetMutator($key)) { // handle new attribute mutator
             $this->setAttributeMarkedMutatedAttributeValue($key, $value);
 
             $value = $this->attributes[$key];
@@ -287,11 +287,11 @@ trait HasTranslations
 
     protected function filterTranslations(mixed $value = null, ?string $locale = null, ?array $allowedLocales = null, bool $allowNull = false, bool $allowEmptyString = false): bool
     {
-        if ($value === null && !$allowNull) {
+        if ($value === null && ! $allowNull) {
             return false;
         }
 
-        if ($value === '' && !$allowEmptyString) {
+        if ($value === '' && ! $allowEmptyString) {
             return false;
         }
 
@@ -375,7 +375,7 @@ trait HasTranslations
     public function scopeWhereJsonContainsLocales(Builder $query, string $column, array $locales, mixed $value, string $operand = '='): void
     {
         $query->where(function (Builder $query) use ($column, $locales, $value, $operand) {
-            foreach($locales as $locale) {
+            foreach ($locales as $locale) {
                 $query->orWhere("{$column}->{$locale}", $operand, $value);
             }
         });

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -34,4 +34,18 @@ class Translatable
 
         return $this;
     }
+
+    public function allowNullForTranslation(bool $allowNullForTranslation = true): self
+    {
+        $this->allowNullForTranslation = $allowNullForTranslation;
+
+        return $this;
+    }
+
+    public function allowEmptyStringForTranslation(bool $allowEmptyStringForTranslation = true): self
+    {
+        $this->allowEmptyStringForTranslation = $allowEmptyStringForTranslation;
+
+        return $this;
+    }
 }

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -19,6 +19,10 @@ class Translatable
 
     public ?Closure $missingKeyCallback = null;
 
+    public bool $allowNullForTranslation = false;
+
+    public bool $allowEmptyStringForTranslation = false;
+
     public function fallback(
         ?string $fallbackLocale = null,
         ?bool $fallbackAny = false,

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -836,7 +836,7 @@ it('should return null when the underlying attribute in database is null', funct
     // we need to remove the name attribute from the translatable array
     // and add it back to make sure the name
     // attribute is holding `null` raw value
-    $this->testModel->translatable = array_filter($this->testModel->translatable, fn($attribute) => $attribute !== 'name');
+    $this->testModel->translatable = array_filter($this->testModel->translatable, fn ($attribute) => $attribute !== 'name');
     $this->testModel->name = null;
     $this->testModel->translatable = array_merge($this->testModel->translatable, ['name']);
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -831,3 +831,56 @@ it('translations macro meets expectations', function (mixed $expected, string|ar
     [['en' => 'english', 'nl' => 'english'], ['en', 'nl'], 'english'],
     [['en' => 'english', 'nl' => 'dutch'], ['en', 'nl'], ['english', 'dutch']],
 ]);
+
+it('should return null when the underlying attribute in database is null', function () {
+    // we need to remove the name attribute from the translatable array
+    // and add it back to make sure the name
+    // attribute is holding `null` raw value
+    $this->testModel->translatable = array_filter($this->testModel->translatable, fn($attribute) => $attribute !== 'name');
+    $this->testModel->name = null;
+    $this->testModel->translatable = array_merge($this->testModel->translatable, ['name']);
+
+    $translation = $this->testModel->getTranslation('name', 'en');
+
+    expect($translation)->toBeNull();
+});
+
+it('should return locales with empty string translations when allowEmptyStringForTranslation is true', function () {
+    Translatable::allowEmptyStringForTranslation();
+
+    $this->testModel->setTranslation('name', 'en', '');
+
+    $translations = $this->testModel->getTranslations('name');
+
+    expect($translations)->toEqual(['en' => '']);
+});
+
+it('should not return locales with empty string translations when allowEmptyStringForTranslation is false', function () {
+    Translatable::allowEmptyStringForTranslation(false);
+
+    $this->testModel->setTranslation('name', 'en', '');
+
+    $translations = $this->testModel->getTranslations('name');
+
+    expect($translations)->toEqual([]);
+});
+
+it('should return locales with null translations when allowNullForTranslation is true', function () {
+    Translatable::allowNullForTranslation();
+
+    $this->testModel->setTranslation('name', 'en', null);
+
+    $translations = $this->testModel->getTranslations('name');
+
+    expect($translations)->toEqual(['en' => null]);
+});
+
+it('should not return locales with null translations when allowNullForTranslation is false', function () {
+    Translatable::allowNullForTranslation(false);
+
+    $this->testModel->setTranslation('name', 'en', null);
+
+    $translations = $this->testModel->getTranslations('name');
+
+    expect($translations)->toEqual([]);
+});


### PR DESCRIPTION
This pull request introduces configuration options to control how null and empty string values are handled in translations. It also handles a case where the column value is `null` it returns `null` instead of empty string.

## Background

- Pull request #427 introduced a change that allowed expecting null values where previously it would return an unexpected value. This was a positive change for future development.
- However, this caused issues for existing production deployments where code relied on the previous behavior.
- Pull request #428 reverted the changes introduced in #427.

## Solution:

This pull request provides a solution that addresses both scenarios:

- Maintains the default behavior of the library.
- Introduces a configuration option to allow developers to explicitly return null and empty strings where expected.

## Benefits:

- Existing codebases don't require immediate changes.
- Developers can now configure the library for specific needs.
- Improved flexibility and future-proofing.
