### PR TITLE
Improve `setAttribute` to handle array list as value for translation

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -49,14 +49,15 @@ trait HasTranslations
 
     public function setAttribute($key, $value)
     {
-        if ($this->isTranslatableAttribute($key)) {
-            if (is_array($value) && ! array_is_list($value)) {
-                return $this->setTranslations($key, $value);
-            }
-            return $this->setTranslation($key, $this->getLocale(), $value);
+        if (!$this->isTranslatableAttribute($key)) {
+            return parent::setAttribute($key, $value);
         }
 
-        return parent::setAttribute($key, $value);
+        if (is_array($value) && ! array_is_list($value)) {
+            return $this->setTranslations($key, $value);
+        }
+
+        return $this->setTranslation($key, $this->getLocale(), $value);
     }
 
     public function translate(string $key, string $locale = '', bool $useFallbackLocale = true): mixed

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -49,7 +49,7 @@ trait HasTranslations
 
     public function setAttribute($key, $value)
     {
-        if (!$this->isTranslatableAttribute($key)) {
+        if (! $this->isTranslatableAttribute($key)) {
             return parent::setAttribute($key, $value);
         }
 

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -49,18 +49,14 @@ trait HasTranslations
 
     public function setAttribute($key, $value)
     {
-        if ($this->isTranslatableAttribute($key) && is_array($value)) {
-            return $this->setTranslations($key, $value);
+        if ($this->isTranslatableAttribute($key)) {
+            if (is_array($value) && ! array_is_list($value)) {
+                return $this->setTranslations($key, $value);
+            }
+            return $this->setTranslation($key, $this->getLocale(), $value);
         }
 
-        // Pass arrays and untranslatable attributes to the parent method.
-        if (! $this->isTranslatableAttribute($key) || is_array($value)) {
-            return parent::setAttribute($key, $value);
-        }
-
-        // If the attribute is translatable and not already translated, set a
-        // translation for the current app locale.
-        return $this->setTranslation($key, $this->getLocale(), $value);
+        return parent::setAttribute($key, $value);
     }
 
     public function translate(string $key, string $locale = '', bool $useFallbackLocale = true): mixed

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -884,3 +884,17 @@ it('should not return locales with null translations when allowNullForTranslatio
 
     expect($translations)->toEqual([]);
 });
+
+it('can set an array list as value for translation using `setTranslation`', function () {
+    $this->testModel->setTranslation('name', 'en', ['testValue_en']);
+    $this->testModel->save();
+
+    expect($this->testModel->getTranslation('name', 'en'))->toEqual(['testValue_en']);
+});
+
+it('can set an array list as value for translation using default local', function () {
+    $this->testModel->name = ['testValue_en'];
+    $this->testModel->save();
+
+    expect($this->testModel->getTranslation('name', 'en'))->toEqual(['testValue_en']);
+});


### PR DESCRIPTION
This PR enhances the `setAttribute` method in the `HasTranslations` trait to handle array values for translatable attributes. 

**Motivation**

Previously, setting an array value for a translatable attribute would result in unexpected behavior, treating array indexes as locale keys. For example:

```php
$model->additional_info = ['Feature 1', 'Feature 2', 'Feature 3'];
```
Would store:
```json
{
  "0": "Feature 1",
  "1": "Feature 2",
  "2": "Feature 3"
}
```

With this change, the array is now stored as a translation for the current locale:
```json
{
  "en": ["Feature 1", "Feature 2", "Feature 3"]
}
```

Tests were added to verify the correct behavior of the `setAttribute` method with array values.