### PR TITLE
Fix attribute mutators

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -71,7 +71,7 @@ trait HasTranslations
     public function getTranslation(string $key, string $locale, bool $useFallbackLocale = true): mixed
     {
         // if column value is `null` then we have nothing to do, return `null`
-        if (is_null(parent::getAttributeValue($key))) {
+        if (is_null(parent::getAttributeFromArray($key))) {
             return null;
         }
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Database\Eloquent\Casts\Attribute as Attribute;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
@@ -526,6 +527,27 @@ it('can set multiple translations on field when a mutator is defined', function 
     $testModel->save();
 
     expect($testModel->getTranslations('field_with_mutator'))->toEqual($translations);
+});
+
+it('uses the attribute to mutate the translated value', function () {
+    $testModel = (new class () extends TestModel {
+        public $mutatedValues = [];
+
+        protected function name(): Attribute
+        {
+            return Attribute::get(function ($value) {
+                $this->mutatedValues[] = $value;
+
+                return 'mutated';
+            });
+        }
+    });
+
+    $testModel->name = 'hello';
+    $testModel->save();
+
+    expect($testModel->name)->toEqual('mutated');
+    expect($testModel->mutatedValues)->toBe(['hello']);
 });
 
 it('can translate a field based on the translations of another one', function () {


### PR DESCRIPTION
Hi,

## Issue

Since the latest version, attribute mutators of translated attributes are getting called twice when getting the translated value.
It is happening because the following change in PR #465 in the `getTranslation` method:
```php
// if column value is `null` then we have nothing to do, return `null`
if (is_null(parent::getAttributeValue($key))) {
    return null;
}
```

`parent::getAttributeValue` will try to transform the value using the attribute, which causes it to be called with the raw value stored in the database.

It wouldn't be a big issue but in my case I have a translated date which I'd like to parse into Carbon.
For example:
```php
use Carbon\Carbon;
use Illuminate\Database\Eloquent\Casts\Attribute;
use Illuminate\Database\Eloquent\Model;
use Spatie\Translatable\HasTranslations;

class Example extends Model
{
    use HasTranslations;

    public $translatable = ['date'];

    /** @return Attribute<Carbon, never> */
    public function date(): Attribute
    {
        return Attribute::get(fn ($value) => Carbon::parse($value));
    }
}
```

Getting the value raises an exception in this case:
```php
$example = new Example();
$example->date = now();
$example->save();

$example->date; // Should be a Carbon object
```
```
Could not parse '{"en":"2024-12-10T20:01:47.992298Z"}'
```

I have added a simple test to reproduce the issue, you can see that it is getting called with the raw value first:
![image](https://github.com/user-attachments/assets/b56381bc-4eb0-4f20-b156-e967dec0ffcb)

## Fix
This PR solves this issue by using the untransformed value for the null check instead.