### PR TITLE
Revert return value change when column value is `null`

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -67,11 +67,6 @@ trait HasTranslations
 
     public function getTranslation(string $key, string $locale, bool $useFallbackLocale = true): mixed
     {
-        // if column value is `null` then we have nothing to do, return `null`
-        if (is_null(parent::getAttributeFromArray($key))) {
-            return null;
-        }
-
         $normalizedLocale = $this->normalizeLocale($key, $locale, $useFallbackLocale);
 
         $isKeyMissingFromLocale = ($locale !== $normalizedLocale);

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -854,7 +854,7 @@ it('translations macro meets expectations', function (mixed $expected, string|ar
     [['en' => 'english', 'nl' => 'dutch'], ['en', 'nl'], ['english', 'dutch']],
 ]);
 
-it('should return null when the underlying attribute in database is null', function () {
+it('should return empty string when the underlying attribute in database is null', function () {
     // we need to remove the name attribute from the translatable array
     // and add it back to make sure the name
     // attribute is holding `null` raw value
@@ -864,7 +864,7 @@ it('should return null when the underlying attribute in database is null', funct
 
     $translation = $this->testModel->getTranslation('name', 'en');
 
-    expect($translation)->toBeNull();
+    expect($translation)->toBe('');
 });
 
 it('should return locales with empty string translations when allowEmptyStringForTranslation is true', function () {


### PR DESCRIPTION
Hi,

- I've noticed that PR #465 changed the default behaviour and now `getTranslation` returns `null` instead of an empty string when the column value is `null`.
- This change also causes attribute mutators to not run in this case, which makes some use-cases impossible that has been working before. (Partially caused by my previous PR #470 since it corrected this behaviour.)

I've removed the modifications from `getTranslation` and modified the test to reflect that.
I've also tested the modified test in a prior version (6.8.0) to verify that the return value was an empty string before.

Fixes #473