### PR TITLE
Support clearing translations using an empty array

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -53,7 +53,7 @@ trait HasTranslations
             return parent::setAttribute($key, $value);
         }
 
-        if (is_array($value) && ! array_is_list($value)) {
+        if (is_array($value) && (! array_is_list($value) || count($value) === 0)) {
             return $this->setTranslations($key, $value);
         }
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -920,3 +920,10 @@ it('can set an array list as value for translation using default local', functio
 
     expect($this->testModel->getTranslation('name', 'en'))->toEqual(['testValue_en']);
 });
+
+it('can treat an empty array as value for clearing translations', function () {
+    $this->testModel->name = [];
+    $this->testModel->save();
+
+    expect($this->testModel->getTranslations('name'))->toEqual([]);
+});


### PR DESCRIPTION
This PR introduces support for clearing translations by assigning an empty array to a translatable attribute.

## Changes:

- Modified the `setAttribute` method to handle empty arrays ([]) as a valid input for clearing translations, in addition to the existing behavior for non-list arrays.

- Added a test to ensure that assigning an empty array to a translatable attribute clears all translations for that attribute.

## Why this is needed:

- It fixes #476 

Let me know if any additional updates or documentation are required!