### PR TITLE
Handle null database values as null in translations

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -73,7 +73,7 @@ trait HasTranslations
 
         $translations = $this->getTranslations($key);
 
-        $translation = $translations[$normalizedLocale] ?? '';
+        $translation = is_null(self::getAttributeFromArray($key)) ? null : $translations[$normalizedLocale] ?? '';
 
         $translatableConfig = app(Translatable::class);
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -854,7 +854,7 @@ it('translations macro meets expectations', function (mixed $expected, string|ar
     [['en' => 'english', 'nl' => 'dutch'], ['en', 'nl'], ['english', 'dutch']],
 ]);
 
-it('should return empty string when the underlying attribute in database is null', function () {
+it('should return null when the underlying attribute in database is null', function () {
     // we need to remove the name attribute from the translatable array
     // and add it back to make sure the name
     // attribute is holding `null` raw value
@@ -864,7 +864,7 @@ it('should return empty string when the underlying attribute in database is null
 
     $translation = $this->testModel->getTranslation('name', 'en');
 
-    expect($translation)->toBe('');
+    expect($translation)->toBeNull();
 });
 
 it('should return locales with empty string translations when allowEmptyStringForTranslation is true', function () {


### PR DESCRIPTION
This pull requests is originated from the conversation on #474 where @vencelkatai and i agreed on finding a way to have an implementation that satisfies our use cases and also keep the library consistent.

## Changes

- Modified the `getTranslation` method to check if the raw attribute value is `null` using `self::getAttributeFromArray`. If the attribute is `null`, it will now treat the translation as `null` instead of falling back to an empty string.

## Why This Change Is Needed

Previously, `null` values in the database were treated inconsistently, being returned as empty strings in translations. This behavior could lead to unexpected results in applications that differentiate between `null` and empty strings. By aligning the translation output with the underlying database value, this change ensures more predictable and intuitive behavior.

## Next Steps

Please @freekmurze and @vencelkatai review the changes and share your feedback. If the approach aligns with expectations, I’ll proceed with further documentation or additional tests if necessary.

Thank you!