### PR TITLE
Allow null value in translations if allowNullForTranslation is true

### DIFF
--- a/src/Facades/Translatable.php
+++ b/src/Facades/Translatable.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * @see \Spatie\Translatable\Translatable
  *
  * @method static void fallback(?string $fallbackLocale = null, ?bool $fallbackAny = false, $missingKeyCallback = null)
+ * @method static void allowNullForTranslation(bool $allowNullForTranslation = true)
+ * @method static void allowEmptyStringForTranslation(bool $allowEmptyStringForTranslation = true)
  */
 class Translatable extends Facade
 {

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -94,7 +94,7 @@ trait HasTranslations
 
         if ($isKeyMissingFromLocale && $translatableConfig->missingKeyCallback) {
             try {
-                $callbackReturnValue = (app(Translatable::class)->missingKeyCallback)($this, $key, $locale, $translation, $normalizedLocale);
+                $callbackReturnValue = ($translatableConfig->missingKeyCallback)($this, $key, $locale, $translation, $normalizedLocale);
                 if (is_string($callbackReturnValue)) {
                     $translation = $callbackReturnValue;
                 }

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -83,9 +83,14 @@ trait HasTranslations
 
         $baseKey = Str::before($key, '->'); // get base key in case it is JSON nested key
 
-        $translation = is_null(self::getAttributeFromArray($baseKey)) ? null : $translations[$normalizedLocale] ?? '';
-
         $translatableConfig = app(Translatable::class);
+
+        if (is_null(self::getAttributeFromArray($baseKey))) {
+            $translation = null;
+        } else {
+            $translation = isset($translations[$normalizedLocale]) ? $translations[$normalizedLocale] : null;
+            $translation ??= ($translatableConfig->allowNullForTranslation) ? null : '';
+        }
 
         if ($isKeyMissingFromLocale && $translatableConfig->missingKeyCallback) {
             try {

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -1028,3 +1028,13 @@ it('should return null when translation is null and allowNullForTranslation is t
 
     expect($translation)->toBeNull();
 });
+
+it('should return empty string when translation is null and allowNullForTranslation is false', function () {
+    Translatable::allowNullForTranslation(false);
+
+    $this->testModel->setTranslation('name', 'en', null);
+
+    $translation = $this->testModel->getTranslation('name', 'en');
+
+    expect($translation)->toBe('');
+});

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -1018,3 +1018,13 @@ it('uses mutators for setting and getting translated values of nested fields', f
     expect($testModel->$nestedDeepFieldKey)
         ->toEqual('Nested deep field ar');
 });
+
+it('should return null when translation is null and allowNullForTranslation is true', function () {
+    Translatable::allowNullForTranslation(true);
+
+    $this->testModel->setTranslation('name', 'en', null);
+
+    $translation = $this->testModel->getTranslation('name', 'en');
+
+    expect($translation)->toBeNull();
+});


### PR DESCRIPTION
Hi there,

When saving a translation with the `null` value an empty string will be returned when retrieving a translation. This behavior was discussed here https://github.com/spatie/laravel-translatable/issues/195 and was attempted to be fixed here https://github.com/spatie/laravel-translatable/pull/427 , but caused errors in projects using a string as the default value.

These errors were fixed in the PR https://github.com/spatie/laravel-translatable/pull/465  by adding `allowNullForTranslation` configuration  which is `false` by default.

But it still returns an empty string when retrieving a translation with a `null` value. This PR fixes this behavior and returns `null` instead of an empty string if `allowNullForTranslation` is `true`.