### PR TITLE
Handle Plain Text Translations for Existing Data

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -97,7 +97,6 @@ trait HasTranslations
                     is_null(json_decode($rawValue, true)) &&
                     json_last_error() !== JSON_ERROR_NONE
                 ) {
-                    dd($rawValue);
                     $translation = $rawValue;
 
                 } else {

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -88,8 +88,27 @@ trait HasTranslations
         if (is_null(self::getAttributeFromArray($baseKey))) {
             $translation = null;
         } else {
-            $translation = isset($translations[$normalizedLocale]) ? $translations[$normalizedLocale] : null;
-            $translation ??= ($translatableConfig->allowNullForTranslation) ? null : '';
+               $rawValue = self::getAttributeFromArray($baseKey);
+
+               if (
+                    $useFallbackLocale &&
+                    !is_null($rawValue) &&
+                    is_string($rawValue) &&
+                    is_null(json_decode($rawValue, true)) &&
+                    json_last_error() !== JSON_ERROR_NONE
+                ) {
+                    dd($rawValue);
+                    $translation = $rawValue;
+
+                } else {
+                    $translation = $translations[$normalizedLocale] ?? null;
+
+                    if ($translation === null && $useFallbackLocale && $locale !== $normalizedLocale) {
+                        $translation = $translations[$locale] ?? null;
+                    }
+
+                    $translation ??= ($translatableConfig->allowNullForTranslation) ? null : '';
+                }
         }
 
         if ($isKeyMissingFromLocale && $translatableConfig->missingKeyCallback) {

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -88,26 +88,25 @@ trait HasTranslations
         if (is_null(self::getAttributeFromArray($baseKey))) {
             $translation = null;
         } else {
-               $rawValue = self::getAttributeFromArray($baseKey);
+            $rawValue = self::getAttributeFromArray($baseKey);
 
-               if (
-                    $useFallbackLocale &&
-                    !is_null($rawValue) &&
-                    is_string($rawValue) &&
-                    is_null(json_decode($rawValue, true)) &&
-                    json_last_error() !== JSON_ERROR_NONE
-                ) {
-                    $translation = $rawValue;
+            if (
+                $useFallbackLocale &&
+                !is_null($rawValue) &&
+                is_string($rawValue) &&
+                is_null(json_decode($rawValue, true)) &&
+                json_last_error() !== JSON_ERROR_NONE
+            ) {
+                $translation = $rawValue;
+            } else {
+                $translation = $translations[$normalizedLocale] ?? null;
 
-                } else {
-                    $translation = $translations[$normalizedLocale] ?? null;
-
-                    if ($translation === null && $useFallbackLocale && $locale !== $normalizedLocale) {
-                        $translation = $translations[$locale] ?? null;
-                    }
-
-                    $translation ??= ($translatableConfig->allowNullForTranslation) ? null : '';
+                if ($translation === null && $useFallbackLocale && $locale !== $normalizedLocale) {
+                    $translation = $translations[$locale] ?? null;
                 }
+
+                $translation ??= ($translatableConfig->allowNullForTranslation) ? null : '';
+            }
         }
 
         if ($isKeyMissingFromLocale && $translatableConfig->missingKeyCallback) {


### PR DESCRIPTION
Handle case when the package is installed on an existing project with actual data stored in the database as plain text instead of JSON translations.
If the value is plain text and not valid JSON, return it directly when using the fallback locale.