### PR TITLE
Add PHP attribute support for defining translatable columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ class NewsItem extends Model
 }
 ```
 
+Alternatively, you can use the `#[Translatable]` PHP attribute instead of the `$translatable` property:
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\Attributes\Translatable;
+use Spatie\Translatable\HasTranslations;
+
+#[Translatable('name')]
+class NewsItem extends Model
+{
+    use HasTranslations;
+
+    // ...
+}
+```
+
+The attribute accepts either a variadic list of column names (`#[Translatable('name', 'description')]`) or a single array (`#[Translatable(['name', 'description'])]`). When both the property and the attribute are present, their values are merged.
+
 After the trait is applied on the model you can do these things:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class NewsItem extends Model
 }
 ```
 
-The attribute accepts either a variadic list of column names (`#[Translatable('name', 'description')]`) or a single array (`#[Translatable(['name', 'description'])]`). When both the property and the attribute are present, their values are merged.
+The attribute accepts either a variadic list of column names (`#[Translatable('name', 'description')]`) or a single array (`#[Translatable(['name', 'description'])]`). When both the property and the attribute are present, their values are merged and deduplicated.
 
 After the trait is applied on the model you can do these things:
 

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -45,4 +45,4 @@ class NewsItem extends Model
 }
 ```
 
-The attribute accepts either a variadic list of column names (`#[Translatable('name', 'description')]`) or a single array (`#[Translatable(['name', 'description'])]`). When both the property and the attribute are present, their values are merged.
+The attribute accepts either a variadic list of column names (`#[Translatable('name', 'description')]`) or a single array (`#[Translatable(['name', 'description'])]`). When both the property and the attribute are present, their values are merged and deduplicated.

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -14,7 +14,7 @@ composer require spatie/laravel-translatable
 The required steps to make a model translatable are:
 
 - First, you need to add the `Spatie\Translatable\HasTranslations`-trait.
-- Next, you should create a public property `$translatable` which holds an array with all the names of attributes you wish to make translatable.
+- Next, you should declare which attributes are translatable, either through a public `$translatable` property or the `#[Translatable]` PHP attribute.
 - Finally, you should make sure that all translatable attributes are set to the `json`-datatype in your database. If your database doesn't support `json`-columns, use `text`.
 
 Here's an example of a prepared model:
@@ -29,3 +29,20 @@ class NewsItem extends Model
 
     public array $translatable = ['name'];
 }
+```
+
+Alternatively, you can use the `#[Translatable]` PHP attribute instead of the `$translatable` property:
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\Attributes\Translatable;
+use Spatie\Translatable\HasTranslations;
+
+#[Translatable('name')]
+class NewsItem extends Model
+{
+    use HasTranslations;
+}
+```
+
+The attribute accepts either a variadic list of column names (`#[Translatable('name', 'description')]`) or a single array (`#[Translatable(['name', 'description'])]`). When both the property and the attribute are present, their values are merged.

--- a/src/Attributes/Translatable.php
+++ b/src/Attributes/Translatable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Translatable\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Translatable
+{
+    public array $columns;
+
+    public function __construct(array|string ...$columns)
+    {
+        $this->columns = is_array($columns[0] ?? null) ? $columns[0] : $columns;
+    }
+}

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -16,6 +16,8 @@ trait HasTranslations
 {
     protected ?string $translationLocale = null;
 
+    protected static array $translatableAttributesCache = [];
+
     public function initializeHasTranslations(): void
     {
         $this->mergeCasts(
@@ -359,6 +361,10 @@ trait HasTranslations
 
     protected function getTranslatableColumnsFromAttribute(): array
     {
+        if (array_key_exists(static::class, static::$translatableAttributesCache)) {
+            return static::$translatableAttributesCache[static::class];
+        }
+
         try {
             $reflection = new ReflectionClass($this);
 
@@ -366,14 +372,14 @@ trait HasTranslations
                 $attributes = $reflection->getAttributes(TranslatableAttribute::class);
 
                 if (count($attributes) > 0) {
-                    return $attributes[0]->newInstance()->columns;
+                    return static::$translatableAttributesCache[static::class] = $attributes[0]->newInstance()->columns;
                 }
             } while ($reflection = $reflection->getParentClass());
         } catch (Exception) {
             //
         }
 
-        return [];
+        return static::$translatableAttributesCache[static::class] = [];
     }
 
     public function translations(): Attribute

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -361,10 +361,11 @@ trait HasTranslations
 
     protected function getTranslatableColumnsFromAttribute(): array
     {
-        if (array_key_exists(static::class, static::$translatableAttributesCache)) {
-            return static::$translatableAttributesCache[static::class];
-        }
+        return static::$translatableAttributesCache[static::class] ??= $this->resolveTranslatableColumnsFromAttribute();
+    }
 
+    protected function resolveTranslatableColumnsFromAttribute(): array
+    {
         try {
             $reflection = new ReflectionClass($this);
 
@@ -372,14 +373,14 @@ trait HasTranslations
                 $attributes = $reflection->getAttributes(TranslatableAttribute::class);
 
                 if (count($attributes) > 0) {
-                    return static::$translatableAttributesCache[static::class] = $attributes[0]->newInstance()->columns;
+                    return $attributes[0]->newInstance()->columns;
                 }
             } while ($reflection = $reflection->getParentClass());
         } catch (Exception) {
             //
         }
 
-        return static::$translatableAttributesCache[static::class] = [];
+        return [];
     }
 
     public function translations(): Attribute

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use ReflectionClass;
+use Spatie\Translatable\Attributes\Translatable as TranslatableAttribute;
 use Spatie\Translatable\Events\TranslationHasBeenSetEvent;
 use Spatie\Translatable\Exceptions\AttributeIsNotTranslatable;
 
@@ -346,9 +348,32 @@ trait HasTranslations
 
     public function getTranslatableAttributes(): array
     {
-        return is_array($this->translatable)
+        $attributes = is_array($this->translatable ?? null)
             ? $this->translatable
             : [];
+
+        return array_values(array_unique(
+            array_merge($attributes, $this->getTranslatableColumnsFromAttribute()),
+        ));
+    }
+
+    protected function getTranslatableColumnsFromAttribute(): array
+    {
+        try {
+            $reflection = new ReflectionClass($this);
+
+            do {
+                $attributes = $reflection->getAttributes(TranslatableAttribute::class);
+
+                if (count($attributes) > 0) {
+                    return $attributes[0]->newInstance()->columns;
+                }
+            } while ($reflection = $reflection->getParentClass());
+        } catch (Exception) {
+            //
+        }
+
+        return [];
     }
 
     public function translations(): Attribute

--- a/tests/TestSupport/TestModelWithAttributeDefinition.php
+++ b/tests/TestSupport/TestModelWithAttributeDefinition.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Translatable\Test\TestSupport;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\Attributes\Translatable;
+use Spatie\Translatable\HasTranslations;
+
+#[Translatable('name', 'other_field')]
+class TestModelWithAttributeDefinition extends Model
+{
+    use HasTranslations;
+
+    protected $table = 'test_models';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+}

--- a/tests/TranslatableAttributeTest.php
+++ b/tests/TranslatableAttributeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Spatie\Translatable\Attributes\Translatable;
+use Spatie\Translatable\HasTranslations;
+use Spatie\Translatable\Test\TestSupport\TestModelWithAttributeDefinition;
+
+it('can get translatable attributes defined via php attribute', function () {
+    $testModel = new TestModelWithAttributeDefinition;
+
+    expect($testModel->getTranslatableAttributes())->toBe(['name', 'other_field']);
+});
+
+it('supports both array and variadic syntax in translatable attribute', function () {
+    $attribute = new Translatable(['name', 'other_field']);
+    expect($attribute->columns)->toBe(['name', 'other_field']);
+
+    $attribute = new Translatable('name', 'other_field');
+    expect($attribute->columns)->toBe(['name', 'other_field']);
+});
+
+it('merges property and attribute definitions', function () {
+    $testModel = new #[Translatable('name', 'other_field')] class extends \Illuminate\Database\Eloquent\Model
+    {
+        use HasTranslations;
+
+        protected $table = 'test_models';
+
+        protected $guarded = [];
+
+        public $timestamps = false;
+
+        public $translatable = ['name', 'field_with_mutator'];
+    };
+
+    expect($testModel->getTranslatableAttributes())->toBe(['name', 'field_with_mutator', 'other_field']);
+});
+
+it('inherits translatable attribute from parent class', function () {
+    $childModel = new class extends TestModelWithAttributeDefinition {};
+
+    expect($childModel->getTranslatableAttributes())->toBe(['name', 'other_field']);
+});

--- a/tests/TranslatableAttributeTest.php
+++ b/tests/TranslatableAttributeTest.php
@@ -1,11 +1,12 @@
 <?php
 
+use Illuminate\Database\Eloquent\Model;
 use Spatie\Translatable\Attributes\Translatable;
 use Spatie\Translatable\HasTranslations;
 use Spatie\Translatable\Test\TestSupport\TestModelWithAttributeDefinition;
 
 it('can get translatable attributes defined via php attribute', function () {
-    $testModel = new TestModelWithAttributeDefinition;
+    $testModel = new TestModelWithAttributeDefinition();
 
     expect($testModel->getTranslatableAttributes())->toBe(['name', 'other_field']);
 });
@@ -19,8 +20,7 @@ it('supports both array and variadic syntax in translatable attribute', function
 });
 
 it('merges property and attribute definitions', function () {
-    $testModel = new #[Translatable('name', 'other_field')] class extends \Illuminate\Database\Eloquent\Model
-    {
+    $testModel = new #[Translatable('name', 'other_field')] class extends Model {
         use HasTranslations;
 
         protected $table = 'test_models';
@@ -39,4 +39,15 @@ it('inherits translatable attribute from parent class', function () {
     $childModel = new class extends TestModelWithAttributeDefinition {};
 
     expect($childModel->getTranslatableAttributes())->toBe(['name', 'other_field']);
+});
+
+it('can set and retrieve translations on a model defined via php attribute', function () {
+    $testModel = new TestModelWithAttributeDefinition();
+
+    $testModel->setTranslation('name', 'en', 'Hello');
+    $testModel->setTranslation('name', 'nl', 'Hallo');
+
+    expect($testModel->getTranslation('name', 'en'))->toBe('Hello');
+    expect($testModel->getTranslation('name', 'nl'))->toBe('Hallo');
+    expect($testModel->getTranslations('name'))->toBe(['en' => 'Hello', 'nl' => 'Hallo']);
 });


### PR DESCRIPTION
## Summary

- Adds a `#[Translatable]` PHP attribute as an alternative to the `$translatable` property, following the same pattern Laravel 13 introduced for `#[Fillable]`, `#[Hidden]`, etc.
- When both the property and attribute are present, they merge (matching Laravel's `mergeFillable()` behavior)
- Attribute is inherited by child classes

## Usage

```php
use Spatie\Translatable\Attributes\Translatable;

#[Translatable('name', 'description')]
class Post extends Model
{
    use HasTranslations;
}
```

Array syntax is also supported: `#[Translatable(['name', 'description'])]`