### PR TITLE
Fix code bug: inconsistent variable name $newsItem -> $newItem in set…

### DIFF
--- a/docs/basic-usage/getting-and-settings-translations.md
+++ b/docs/basic-usage/getting-and-settings-translations.md
@@ -43,13 +43,13 @@ You can set translations for multiple languages with
 
 ```php
 $translations = ['en' => 'hello', 'es' => 'hola'];
-$newItem->name = $translations;
+$newsItem->name = $translations;
 
 // alternatively, use the `setTranslations` method
 
-$newItem->setTranslations('name', $translations);
+$newsItem->setTranslations('name', $translations);
 
-$newItem->save();
+$newsItem->save();
 ```
 
 ## Getting a translation
@@ -106,7 +106,7 @@ $translations = [
     'de' => 'Hallo',
 ];
 
-$newItem->setTranslations('hello', $translations);
+$newsItem->setTranslations('hello', $translations);
 $newsItem->getTranslations('hello', ['en', 'fr']); // returns ['en' => 'Hello', 'fr' => 'Bonjour']
 ```
 
@@ -116,8 +116,8 @@ You can get all locales that a model has by calling `locales()` without an argum
 
 ```php
    $translations = ['en' => 'hello', 'es' => 'hola'];
-   $newItem->name = $translations;
-   $newItem->save();
+   $newsItem->name = $translations;
+   $newsItem->save();
 
-   $newItem->locales(); // returns ['en', 'es']
+   $newsItem->locales(); // returns ['en', 'es']
 ```

--- a/docs/basic-usage/getting-and-settings-translations.md
+++ b/docs/basic-usage/getting-and-settings-translations.md
@@ -47,7 +47,7 @@ $newItem->name = $translations;
 
 // alternatively, use the `setTranslations` method
 
-$newsItem->setTranslations('name', $translations);
+$newItem->setTranslations('name', $translations);
 
 $newItem->save();
 ```
@@ -106,7 +106,7 @@ $translations = [
     'de' => 'Hallo',
 ];
 
-$newsItem->setTranslations('hello', $translations);
+$newItem->setTranslations('hello', $translations);
 $newsItem->getTranslations('hello', ['en', 'fr']); // returns ['en' => 'Hello', 'fr' => 'Bonjour']
 ```
 


### PR DESCRIPTION
…Translations example

In the 'Setting translations for multiple languages' code block, the example used $newItem to declare the variable and assign $translations, but then called setTranslations on $newsItem (different name). This would cause a 'variable undefined' error if copied by a user. Fixed to consistently use $newItem throughout the code block.