### PR TITLE
Add methods for merging, copying, and pruning translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/laravel-translatable.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-translatable)
 [![MIT Licensed](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
-![GitHub Workflow Status](https://github.com/spatie/laravel-translatable/actions/workflows/run-tests.yml/badge.svg)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/spatie/laravel-translatable/run-tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-translatable.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-translatable)
-    
+
 </div>
 
 This package contains a trait `HasTranslations` to make Eloquent models translatable. Translations are stored as json. There is no extra table needed to hold them.
@@ -87,19 +87,34 @@ NewsItem::whereLocale('name', 'en')->get();
 // Returns all news items with a name in English or Dutch
 NewsItem::whereLocales('name', ['en', 'nl'])->get();
 
-// Returns all news items that has name in English with value `Name in English` 
+// Returns all news items missing a French translation
+NewsItem::whereMissingLocale('name', 'fr')->get();
+
+// Returns all news items that has name in English with value `Name in English`
 NewsItem::query()->whereJsonContainsLocale('name', 'en', 'Name in English')->get();
 
-// Returns all news items that has name in English or Dutch with value `Name in English` 
+// Returns all news items that has name in English or Dutch with value `Name in English`
 NewsItem::query()->whereJsonContainsLocales('name', ['en', 'nl'], 'Name in English')->get();
 
 // The last argument is the "operand" which you can tweak to achieve something like this:
 
-// Returns all news items that has name in English with value like `Name in...` 
+// Returns all news items that has name in English with value like `Name in...`
 NewsItem::query()->whereJsonContainsLocale('name', 'en', 'Name in%', 'like')->get();
 
-// Returns all news items that has name in English or Dutch with value like `Name in...` 
+// Returns all news items that has name in English or Dutch with value like `Name in...`
 NewsItem::query()->whereJsonContainsLocales('name', ['en', 'nl'], 'Name in%', 'like')->get();
+
+// Merges the given translations with the existing translations
+NewsItem::query()->mergeTranslations('name', [
+    'en' => 'Updated English name',
+    'fr' => 'Nom en français',
+]);
+
+// Copies the English translation to German
+NewsItem::query()->copyTranslation('name', 'en', 'de');
+
+// Removes empty translations for the name attribute
+NewsItem::query()->pruneEmptyTranslations('name');
 ```
 
 ## Support us

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -488,5 +488,4 @@ trait HasTranslations
             }
         });
     }
-
 }

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -431,6 +431,44 @@ trait HasTranslations
         });
     }
 
+    public function mergeTranslations(string $key, array $translations): self
+    {
+        return $this->setTranslations(
+            $key,
+            array_merge(
+                $this->getTranslations($key),
+                $translations
+            )
+        );
+    }
+
+    public function copyTranslation(string $key, string $from, string $to): self
+    {
+        if ($this->hasTranslation($key, $from)) {
+            $this->setTranslation(
+                $key,
+                $to,
+                $this->getTranslation($key, $from, false)
+            );
+        }
+
+        return $this;
+    }
+
+    public function pruneEmptyTranslations(string $key): self
+    {
+        $translations = array_filter(
+            $this->getTranslations($key),
+            fn ($value) => filled($value)
+        );
+
+        return $this->replaceTranslations($key, $translations);
+    }
+
+    public function scopeWhereMissingLocale(Builder $query, string $column, string $locale): void 
+    {
+        $query->whereNull("{$column}->{$locale}");
+    }
     /**
      * @deprecated
      */
@@ -450,4 +488,5 @@ trait HasTranslations
             }
         });
     }
+
 }


### PR DESCRIPTION
## Summary

This PR adds a few convenience methods to the `HasTranslations` trait to simplify common translation management tasks.

### Added

* `mergeTranslations(string $key, array $translations)` – Merge new translations into the existing translation set without replacing the entire array.
* `copyTranslation(string $key, string $from, string $to)` – Copy a translation value from one locale to another.
* `pruneEmptyTranslations(string $key)` – Remove empty translations for a translatable attribute.
* `whereMissingLocale(string $column, string $locale)` – Query models that are missing a translation for a given locale.

### Documentation

The README has been updated with examples demonstrating the new helper methods and the new query scope.

### Motivation

These operations are common when managing multilingual content and currently require repetitive userland code. Adding them to `HasTranslations` provides a more expressive API while remaining fully backward compatible.
